### PR TITLE
refactor(acm): terraform provider

### DIFF
--- a/infra/modules/acm/main.tf
+++ b/infra/modules/acm/main.tf
@@ -1,3 +1,11 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
 
 resource "aws_acm_certificate" "this" {
   domain_name               = var.domain_name

--- a/infra/modules/acm/versions.tf
+++ b/infra/modules/acm/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}

--- a/infra/modules/acm/versions.tf
+++ b/infra/modules/acm/versions.tf
@@ -1,8 +1,0 @@
-terraform {
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = ">= 5.0"
-    }
-  }
-}

--- a/infra/modules/cloudfront/main.tf
+++ b/infra/modules/cloudfront/main.tf
@@ -7,6 +7,7 @@ resource "aws_cloudfront_origin_access_control" "s3_oac" {
 }
 
 resource "aws_cloudfront_distribution" "frontend" {
+  depends_on          = [var.acm_certificate_arn]
   enabled             = true
   default_root_object = "index.html"
 


### PR DESCRIPTION
This pull request introduces Terraform provider version constraints to the ACM module to ensure compatibility and consistency when using the AWS provider.

Provider version management:

* Added a `terraform` block with an AWS provider version constraint (`>= 5.0`) to both `main.tf` and `versions.tf` in the `infra/modules/acm` module. [[1]](diffhunk://#diff-ca1e46ab4d39c19cfa64b58137e445cdab37bed8b6c83843f1e57093a78c5f61R1-R8) [[2]](diffhunk://#diff-7baa0b47aa7d286b1a8294b1294e9317600ef69801c74764e08b79e10a158a3bR1-R8)