### PR TITLE
fix(infra): correct lambda s3_key, fix vpc count, add lambda build step to apply workflow

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -39,6 +39,9 @@ jobs:
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_wrapper: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
       - uses: actions/cache@v4
         with:
           path: ./infra/.terraform
@@ -52,38 +55,56 @@ jobs:
         env:
           TF_VAR_environment: ${{ inputs.environment || 'prod' }}
 
-      - name: Init & Plan
+      - name: Init
+        run: |
+          echo -e "terraform {\n  backend \"s3\" {}\n}" > backend.tf
+          sed "s/__AWS_ACCOUNT_ID__/$AWS_ACCOUNT_ID/g" backend.conf > backend.conf.tmp
+          if [[ "$ACT" == "true" ]]; then
+            terraform init -backend-config=backend.conf.tmp || echo "Init failed in ACT mode, continuing..."
+          else
+            terraform init -backend-config=backend.conf.tmp
+            terraform validate
+          fi
+        env:
+          AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+          TF_VAR_environment: ${{ inputs.environment || 'prod' }}
+          TF_VAR_aws_account_id: ${{ secrets.AWS_ACCOUNT_ID }}
+
+      - name: Build & Stage Lambda
+        run: |
+          if [[ "$ACT" == "true" ]]; then
+            echo "DRY RUN: Skipping Lambda build"
+          else
+            pip install --target ../backend/dist fastapi uvicorn httpx --quiet
+            cp ../backend/src/main.py ../backend/dist/
+            (cd ../backend/dist && zip -r ../../infra/backend.zip . -q)
+            rm -rf ../backend/dist
+
+            BUCKET="tally-backend-${TF_VAR_environment}-${AWS_ACCOUNT_ID}-us-west-2"
+            terraform apply -auto-approve -target=module.backend_s3 \
+              -var="aws_account_id=${AWS_ACCOUNT_ID}" -var="environment=${TF_VAR_environment}"
+            aws s3 cp backend.zip s3://${BUCKET}/backend.zip
+            rm -f backend.zip
+          fi
+        env:
+          AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+          TF_VAR_environment: ${{ inputs.environment || 'prod' }}
+          TF_VAR_aws_account_id: ${{ secrets.AWS_ACCOUNT_ID }}
+
+      - name: Plan
         id: plan
         run: |
           if [[ "$ACT" == "true" ]]; then
-            echo -e "terraform {\n  backend \"s3\" {}\n}" > backend.tf
-            sed "s/__AWS_ACCOUNT_ID__/$AWS_ACCOUNT_ID/g" backend.conf > backend.conf.tmp
-            terraform init -backend-config=backend.conf.tmp
-            init_exit_code=$?
-            if [[ $init_exit_code -ne 0 ]]; then
-              echo "terraform init failed in ACT mode (exit code: $init_exit_code)"
-              echo "plan_exit_code=2" >> $GITHUB_OUTPUT
-              echo "has_changes=true" >> $GITHUB_OUTPUT
-            else
-              echo "plan_exit_code=0" >> $GITHUB_OUTPUT
-              echo "has_changes=false" >> $GITHUB_OUTPUT
-            fi
+            echo "plan_exit_code=2" >> $GITHUB_OUTPUT
+            echo "has_changes=true" >> $GITHUB_OUTPUT
           else
-            echo -e "terraform {\n  backend \"s3\" {}\n}" > backend.tf
-            sed "s/__AWS_ACCOUNT_ID__/$AWS_ACCOUNT_ID/g" backend.conf > backend.conf.tmp
-            terraform init -backend-config=backend.conf.tmp
-            terraform validate
-            set +e  # Allow plan to exit with non-zero codes
+            set +e
             terraform plan -out=tfplan -detailed-exitcode
             plan_exit_code=$?
-            set -e  # Re-enable exit on error
+            set -e
             echo "plan_exit_code=$plan_exit_code" >> $GITHUB_OUTPUT
             echo "has_changes=$([[ $plan_exit_code -eq 2 ]] && echo true || echo false)" >> $GITHUB_OUTPUT
-            # Exit 0 = no changes, Exit 2 = changes present, Exit 1 = error
-            if [[ $plan_exit_code -eq 1 ]]; then
-              echo "❌ Terraform plan failed with exit code 1"
-              exit 1
-            fi
+            [[ $plan_exit_code -eq 1 ]] && exit 1 || exit 0
           fi
         env:
           AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
@@ -94,7 +115,7 @@ jobs:
         if: steps.plan.outputs.has_changes == 'true' || github.event_name == 'workflow_dispatch'
         run: |
           if [[ "$ACT" == "true" ]]; then
-            echo "🧪 DRY RUN: Would apply changes (exit code: ${{ steps.plan.outputs.plan_exit_code }})"
+            echo "DRY RUN: Would apply changes (exit code: ${{ steps.plan.outputs.plan_exit_code }})"
           else
             terraform apply -auto-approve tfplan
           fi
@@ -106,12 +127,12 @@ jobs:
         if: success()
         run: |
           if [[ "$ACT" == "true" ]]; then
-            echo "✅ ACT test complete (exit: ${{ steps.plan.outputs.plan_exit_code }}, changes: ${{ steps.plan.outputs.has_changes }})"
+            echo "ACT test complete (exit: ${{ steps.plan.outputs.plan_exit_code }}, changes: ${{ steps.plan.outputs.has_changes }})"
           elif [[ "${{ steps.plan.outputs.has_changes }}" == "true" ]]; then
-            echo "✅ Applied $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+            echo "Applied $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
             terraform output 2>/dev/null || echo "No outputs"
           else
-            echo "✅ No changes needed"
+            echo "No changes needed"
           fi
 
       - name: Cleanup

--- a/infra/modules/lambda/main.tf
+++ b/infra/modules/lambda/main.tf
@@ -40,7 +40,7 @@ resource "aws_lambda_function" "backend" {
   handler       = "main.handler"
   runtime       = "python3.13"
   s3_bucket     = var.lambda_code_s3_bucket
-  s3_key        = "backend"
+  s3_key        = "backend.zip"
   role          = aws_iam_role.lambda_exec.arn
 
   vpc_config {

--- a/infra/modules/vpc/main.tf
+++ b/infra/modules/vpc/main.tf
@@ -82,7 +82,7 @@ resource "aws_route_table" "public" {
 
 # Public Route Table Association
 resource "aws_route_table_association" "public" {
-  count = length(aws_subnet.public)
+  count = length(var.availability_zones)
 
   subnet_id      = aws_subnet.public[count.index].id
   route_table_id = aws_route_table.public.id
@@ -90,7 +90,7 @@ resource "aws_route_table_association" "public" {
 
 # Database Route Table (shares public routing - still free!)
 resource "aws_route_table_association" "database" {
-  count = length(aws_subnet.database)
+  count = length(var.availability_zones)
 
   subnet_id      = aws_subnet.database[count.index].id
   route_table_id = aws_route_table.public.id


### PR DESCRIPTION
This pull request updates the Terraform deployment workflow and related infrastructure code to improve the build and deployment process for the backend Lambda function and refines some VPC subnet associations. The changes enhance automation, ensure compatibility with Python 3.13, and streamline Lambda packaging and deployment.

**CI/CD Pipeline Improvements:**

* Added a Python 3.13 setup step to the Terraform GitHub Actions workflow to match the Lambda runtime.
* Split the Terraform workflow into distinct steps: initialization, Lambda build/staging, and planning. The Lambda build step now installs dependencies, packages the code as `backend.zip`, uploads it to S3, and ensures the correct S3 key is used for deployment.
* Simplified and clarified ACT (local runner) handling and output messages in the workflow for easier debugging and local testing. [[1]](diffhunk://#diff-0470b92c7ad1159fdc694ea0893bd0e8bfad6d78173537f0e062e5e01aaf7f5eL97-R118) [[2]](diffhunk://#diff-0470b92c7ad1159fdc694ea0893bd0e8bfad6d78173537f0e062e5e01aaf7f5eL109-R135)

**Infrastructure as Code Updates:**

* Changed the Lambda function's `s3_key` from `"backend"` to `"backend.zip"` to match the new packaging and upload process.
* Updated VPC route table associations to use the length of `var.availability_zones` instead of the subnet resource counts, ensuring proper association across all availability zones.