### PR TITLE
fix(infra): delegate tally subdomain to Route 53 for terraform-managed DNS

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -161,7 +161,7 @@ module "api_gateway" {
 module "route53" {
   source                 = "./modules/route53"
   cloudfront_domain_name = module.cloudfront.cloudfront_domain_name
-  domain_name            = "kenhoward.dev"
+  domain_name            = "tally.kenhoward.dev"
 }
 
 # module "auth0" {

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -37,6 +37,10 @@ provider "aws" {
   # The setup-aws.sh script exports credentials to environment variables
 }
 
+locals {
+  frontend_domain = "tally.kenhoward.dev"
+}
+
 # VPC Module - Zero-Cost Network Foundation
 module "vpc" {
   source = "./modules/vpc"
@@ -66,7 +70,7 @@ module "frontend_s3" {
 # ACM certificate for CloudFront custom domain
 module "acm" {
   source                    = "./modules/acm"
-  domain_name               = "tally.kenhoward.dev"
+  domain_name               = local.frontend_domain
   subject_alternative_names = []
   validation_method         = "DNS"
   providers = {
@@ -81,7 +85,7 @@ module "acm" {
 module "cloudfront" {
   source                  = "./modules/cloudfront"
   bucket_name             = "${var.project}-frontend-${var.environment}-${var.aws_account_id}"
-  aliases                 = ["tally.kenhoward.dev"]
+  aliases                 = [local.frontend_domain]
   acm_certificate_arn     = module.acm.acm_certificate_arn
   api_gateway_domain_name = replace(replace(module.api_gateway.invoke_url, "https://", ""), "/prod", "")
   api_path_pattern        = "/api/v1/*"
@@ -159,9 +163,10 @@ module "api_gateway" {
 # }
 
 module "route53" {
-  source                 = "./modules/route53"
-  cloudfront_domain_name = module.cloudfront.cloudfront_domain_name
-  domain_name            = "tally.kenhoward.dev"
+  source                    = "./modules/route53"
+  cloudfront_domain_name    = module.cloudfront.cloudfront_domain_name
+  cloudfront_hosted_zone_id = module.cloudfront.cloudfront_hosted_zone_id
+  domain_name               = local.frontend_domain
 }
 
 # module "auth0" {

--- a/infra/modules/cloudfront/main.tf
+++ b/infra/modules/cloudfront/main.tf
@@ -90,3 +90,8 @@ output "cloudfront_distribution_arn" {
   description = "CloudFront distribution ARN"
   value       = aws_cloudfront_distribution.frontend.arn
 }
+
+output "cloudfront_hosted_zone_id" {
+  description = "CloudFront distribution hosted zone ID for Route 53 alias records"
+  value       = aws_cloudfront_distribution.frontend.hosted_zone_id
+}

--- a/infra/modules/route53/main.tf
+++ b/infra/modules/route53/main.tf
@@ -1,7 +1,17 @@
-# Route53 Module
-# Define your Route53 hosted zone and DNS records here
 resource "aws_route53_zone" "this" {
   name = var.domain_name
+}
+
+resource "aws_route53_record" "frontend" {
+  zone_id = aws_route53_zone.this.zone_id
+  name    = var.domain_name
+  type    = "A"
+
+  alias {
+    name                   = var.cloudfront_domain_name
+    zone_id                = "Z2FDTNDATAQYW2"
+    evaluate_target_health = false
+  }
 }
 
 output "domain_name" {
@@ -9,15 +19,7 @@ output "domain_name" {
 }
 
 output "name_servers" {
-  description = "Route 53 hosted zone name servers"
+  description = "Add these as NS records in Hover for ${var.domain_name} to delegate the subdomain to Route 53"
   value       = aws_route53_zone.this.name_servers
 }
 
-# DNS record for tally.kenhoward.dev pointing to S3 website endpoint
-resource "aws_route53_record" "frontend" {
-  zone_id = aws_route53_zone.this.zone_id
-  name    = "tally.kenhoward.dev"
-  type    = "CNAME"
-  ttl     = 300
-  records = [var.cloudfront_domain_name]
-}

--- a/infra/modules/route53/main.tf
+++ b/infra/modules/route53/main.tf
@@ -9,7 +9,7 @@ resource "aws_route53_record" "frontend" {
 
   alias {
     name                   = var.cloudfront_domain_name
-    zone_id                = "Z2FDTNDATAQYW2"
+    zone_id                = var.cloudfront_hosted_zone_id
     evaluate_target_health = false
   }
 }

--- a/infra/modules/route53/main.tf
+++ b/infra/modules/route53/main.tf
@@ -19,7 +19,7 @@ output "domain_name" {
 }
 
 output "name_servers" {
-  description = "Add these as NS records in Hover for ${var.domain_name} to delegate the subdomain to Route 53"
+  description = "Add these as NS records in Hover for the subdomain to delegate DNS to Route 53"
   value       = aws_route53_zone.this.name_servers
 }
 

--- a/infra/modules/route53/variables.tf
+++ b/infra/modules/route53/variables.tf
@@ -3,6 +3,11 @@ variable "cloudfront_domain_name" {
   type        = string
 }
 
+variable "cloudfront_hosted_zone_id" {
+  description = "CloudFront distribution hosted zone ID for Route 53 alias records."
+  type        = string
+}
+
 variable "domain_name" {
   description = "The domain name for the Route 53 hosted zone."
   type        = string


### PR DESCRIPTION
This pull request updates the DNS configuration for the `tally.kenhoward.dev` subdomain in the Terraform infrastructure. The main focus is to ensure that the subdomain is correctly delegated and points to the CloudFront distribution using an alias record, aligning with AWS best practices.

**DNS and domain configuration updates:**

* Changed the `domain_name` variable for the Route53 module in `infra/main.tf` from `kenhoward.dev` to `tally.kenhoward.dev`, so the hosted zone now manages the subdomain rather than the root domain.
* Updated the `aws_route53_record.frontend` resource in `infra/modules/route53/main.tf` to use an alias A record pointing to the CloudFront distribution, replacing the previous CNAME record. This is the recommended approach for subdomains with CloudFront.
* Improved the output description for `name_servers` to clarify that these should be added as NS records in Hover to delegate the subdomain to Route 53.