### PR TITLE
chore: use prod environment on apply

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   apply:
     runs-on: ubuntu-latest
+    environment: ${{ inputs.environment || 'prod' }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   apply:
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment || 'prod' }}
+    environment: ${{ github.event.inputs.environment || 'prod' }}
     permissions:
       contents: read
       id-token: write
@@ -53,7 +53,7 @@ jobs:
           aws sts get-caller-identity >/dev/null
           terraform fmt -check -recursive
         env:
-          TF_VAR_environment: ${{ inputs.environment || 'prod' }}
+          TF_VAR_environment: ${{ github.event.inputs.environment || 'prod' }}
 
       - name: Init
         run: |
@@ -62,7 +62,7 @@ jobs:
           terraform validate
         env:
           AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
-          TF_VAR_environment: ${{ inputs.environment || 'prod' }}
+          TF_VAR_environment: ${{ github.event.inputs.environment || 'prod' }}
           TF_VAR_aws_account_id: ${{ secrets.AWS_ACCOUNT_ID }}
 
       - name: Build & Stage Lambda
@@ -79,7 +79,7 @@ jobs:
           rm -f backend.zip
         env:
           AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
-          TF_VAR_environment: ${{ inputs.environment || 'prod' }}
+          TF_VAR_environment: ${{ github.event.inputs.environment || 'prod' }}
           TF_VAR_aws_account_id: ${{ secrets.AWS_ACCOUNT_ID }}
           TF_VAR_database_url_readwrite: ${{ secrets.TALLY_DATABASE_URL_READWRITE }}
           TF_VAR_database_url_readonly: ${{ secrets.TALLY_DATABASE_URL_READONLY }}
@@ -96,7 +96,7 @@ jobs:
           [[ $plan_exit_code -eq 1 ]] && exit 1 || exit 0
         env:
           AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
-          TF_VAR_environment: ${{ inputs.environment || 'prod' }}
+          TF_VAR_environment: ${{ github.event.inputs.environment || 'prod' }}
           TF_VAR_aws_account_id: ${{ secrets.AWS_ACCOUNT_ID }}
           TF_VAR_database_url_readwrite: ${{ secrets.TALLY_DATABASE_URL_READWRITE }}
           TF_VAR_database_url_readonly: ${{ secrets.TALLY_DATABASE_URL_READONLY }}
@@ -105,7 +105,7 @@ jobs:
         if: steps.plan.outputs.has_changes == 'true' || github.event_name == 'workflow_dispatch'
         run: terraform apply -auto-approve tfplan
         env:
-          TF_VAR_environment: ${{ inputs.environment || 'prod' }}
+          TF_VAR_environment: ${{ github.event.inputs.environment || 'prod' }}
           TF_VAR_aws_account_id: ${{ secrets.AWS_ACCOUNT_ID }}
           TF_VAR_database_url_readwrite: ${{ secrets.TALLY_DATABASE_URL_READWRITE }}
           TF_VAR_database_url_readonly: ${{ secrets.TALLY_DATABASE_URL_READONLY }}


### PR DESCRIPTION
This pull request makes a minor update to the `terraform-apply.yml` GitHub Actions workflow by setting the deployment environment dynamically based on an input parameter, defaulting to 'prod' if not specified. 

- The `apply` job now uses the `environment` specified in workflow inputs, or defaults to `'prod'` if not provided (`.github/workflows/terraform-apply.yml`).