### PR TITLE
fix: use github.event.inputs for environment on push-triggered apply

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   apply:
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment || 'prod' }}
+    environment: ${{ github.event.inputs.environment || 'prod' }}
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary
- Addresses a Copilot review comment on #72 (left after merge): `environment: ${{ inputs.environment || 'prod' }}` used the bare `inputs` context, which is only populated for `workflow_dispatch`/`workflow_call`. On `push`, that's inconsistent with the rest of the workflow, which already uses `github.event.inputs.environment || 'prod'` for every other reference. Aligns line 24 with that existing pattern.

## Test plan
- [ ] Confirm `terraform-apply.yml` still resolves the `prod` environment correctly on both `push` and manual `workflow_dispatch` runs