### PR TITLE
fix: track backend.zip content hash so Lambda actually redeploys

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -76,7 +76,8 @@ jobs:
           terraform apply -auto-approve -target=module.backend_s3 \
             -var="aws_account_id=${AWS_ACCOUNT_ID}" -var="environment=${TF_VAR_environment}"
           aws s3 cp backend.zip s3://${BUCKET}/backend.zip
-          rm -f backend.zip
+          # backend.zip is kept (not deleted) so the Plan/Apply steps below can hash it
+          # via source_code_hash and detect that the Lambda function needs updating.
         env:
           AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
           TF_VAR_environment: ${{ github.event.inputs.environment || 'prod' }}

--- a/infra/modules/lambda/main.tf
+++ b/infra/modules/lambda/main.tf
@@ -27,13 +27,21 @@ resource "aws_iam_role_policy_attachment" "lambda_s3_read" {
 }
 
 
+locals {
+  # PR validation plans backend/infra changes without building backend.zip first,
+  # so fall back to null there rather than failing terraform plan.
+  backend_zip_path = "${path.module}/../../backend.zip"
+  backend_zip_hash = fileexists(local.backend_zip_path) ? filebase64sha256(local.backend_zip_path) : null
+}
+
 resource "aws_lambda_function" "backend" {
-  function_name = "${var.project}-backend"
-  handler       = "main.handler"
-  runtime       = "python3.13"
-  s3_bucket     = var.lambda_code_s3_bucket
-  s3_key        = "backend.zip"
-  role          = aws_iam_role.lambda_exec.arn
+  function_name    = "${var.project}-backend"
+  handler          = "main.handler"
+  runtime          = "python3.13"
+  s3_bucket        = var.lambda_code_s3_bucket
+  s3_key           = "backend.zip"
+  source_code_hash = local.backend_zip_hash
+  role             = aws_iam_role.lambda_exec.arn
 
   environment {
     variables = {


### PR DESCRIPTION
## Summary

Investigating "does a backend deploy action exist" (in response to the frontend/backend deploy question) surfaced why `/api/v1/*` is still 502ing even after #72 merged and `terraform-apply.yml` ran successfully: the Lambda function's `s3_key` never changes ("backend.zip"), so Terraform never saw a diff and never called `UpdateFunctionCode` - the corrected zip (with the Mangum handler) sits in S3, but the live function is still running the old broken code from six weeks ago.

- Adds `source_code_hash = fileexists(...) ? filebase64sha256(...) : null` on `aws_lambda_function.backend`, tied to the locally-built `backend.zip`. Falls back to `null` when the zip doesn't exist so `terraform-pr.yml`'s plan-only validation (which never builds the zip) doesn't break.
- Stops `terraform-apply.yml` from deleting `backend.zip` right after uploading it to S3 - it needs to still be on disk when the later `Plan`/`Apply` steps hash it.

Verified locally: with no `backend.zip` present, `terraform plan` shows no diff (safe for PR validation). With a freshly built `backend.zip` present, `terraform plan` correctly shows `1 to change` (updating `source_code_hash`, which triggers the actual code update).

## Test plan

- [x] `terraform validate` passes
- [x] `terraform plan` with no `backend.zip` present: no changes (matches `terraform-pr.yml`'s environment)
- [x] `terraform plan` with a rebuilt `backend.zip` present: `1 to change` on `aws_lambda_function.backend`
- [ ] Merge, confirm `terraform-apply.yml` actually updates the function this time, and confirm `/api/v1/*` no longer 502s