### PR TITLE
fix: CloudFront /api/v1/* routing (headers, stage path, environment-aware config)

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -76,6 +76,7 @@ module "cloudfront" {
   aliases                 = [local.frontend_domain]
   acm_certificate_arn     = module.acm.acm_certificate_arn
   api_gateway_domain_name = replace(replace(module.api_gateway.invoke_url, "https://", ""), "/prod", "")
+  api_origin_path         = "/${split("/", module.api_gateway.invoke_url)[3]}"
   api_path_pattern        = "/api/v1/*"
   tags = {
     Environment = var.environment
@@ -99,7 +100,7 @@ module "lambda" {
 module "api_gateway" {
   source              = "./modules/api_gateway"
   lambda_function_arn = module.lambda.backend_lambda_function_arn
-  stage_name          = "prod"
+  stage_name          = var.environment
   api_name            = "tally-api"
   aws_region          = var.aws_region
 }

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -75,8 +75,8 @@ module "cloudfront" {
   bucket_name             = "${var.project}-frontend-${var.environment}-${var.aws_account_id}"
   aliases                 = [local.frontend_domain]
   acm_certificate_arn     = module.acm.acm_certificate_arn
-  api_gateway_domain_name = replace(replace(module.api_gateway.invoke_url, "https://", ""), "/prod", "")
-  api_origin_path         = "/${split("/", module.api_gateway.invoke_url)[3]}"
+  api_gateway_domain_name = split("/", replace(module.api_gateway.invoke_url, "https://", ""))[0]
+  api_origin_path         = "/${var.environment}"
   api_path_pattern        = "/api/v1/*"
   tags = {
     Environment = var.environment

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -39,6 +39,13 @@ provider "aws" {
 
 locals {
   frontend_domain = "tally.kenhoward.dev"
+
+  # module.api_gateway.invoke_url looks like "https://<id>.execute-api.<region>.amazonaws.com/<stage>".
+  # The REST API id/region aren't available anywhere else, so the domain has to come
+  # from this URL. The stage segment is always var.environment (module.api_gateway is
+  # called with stage_name = var.environment below) - used directly rather than
+  # re-parsed back out of the URL for the same value.
+  api_gateway_domain_name = split("/", replace(module.api_gateway.invoke_url, "https://", ""))[0]
 }
 
 
@@ -75,7 +82,7 @@ module "cloudfront" {
   bucket_name             = "${var.project}-frontend-${var.environment}-${var.aws_account_id}"
   aliases                 = [local.frontend_domain]
   acm_certificate_arn     = module.acm.acm_certificate_arn
-  api_gateway_domain_name = split("/", replace(module.api_gateway.invoke_url, "https://", ""))[0]
+  api_gateway_domain_name = local.api_gateway_domain_name
   api_origin_path         = "/${var.environment}"
   api_path_pattern        = "/api/v1/*"
   tags = {

--- a/infra/modules/cloudfront/main.tf
+++ b/infra/modules/cloudfront/main.tf
@@ -20,6 +20,7 @@ resource "aws_cloudfront_distribution" "frontend" {
   origin {
     domain_name = var.api_gateway_domain_name
     origin_id   = "api-gateway"
+    origin_path = var.api_origin_path
     custom_origin_config {
       http_port              = 80
       https_port             = 443

--- a/infra/modules/cloudfront/main.tf
+++ b/infra/modules/cloudfront/main.tf
@@ -55,7 +55,7 @@ resource "aws_cloudfront_distribution" "frontend" {
     max_ttl                = 0
     forwarded_values {
       query_string = true
-      headers      = ["*", "Authorization"]
+      headers      = ["*"]
       cookies {
         forward = "all"
       }

--- a/infra/modules/cloudfront/main.tf
+++ b/infra/modules/cloudfront/main.tf
@@ -1,3 +1,11 @@
+data "aws_cloudfront_cache_policy" "caching_disabled" {
+  name = "Managed-CachingDisabled"
+}
+
+data "aws_cloudfront_origin_request_policy" "all_viewer_except_host_header" {
+  name = "Managed-AllViewerExceptHostHeader"
+}
+
 resource "aws_cloudfront_origin_access_control" "s3_oac" {
   name                              = "${var.bucket_name}-oac"
   description                       = "OAC for S3 static site"
@@ -53,14 +61,14 @@ resource "aws_cloudfront_distribution" "frontend" {
     viewer_protocol_policy = "redirect-to-https"
 
     # Managed-CachingDisabled: this behavior proxies a live API, not cacheable content.
-    cache_policy_id = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad"
+    cache_policy_id = data.aws_cloudfront_cache_policy.caching_disabled.id
 
     # Managed-AllViewerExceptHostHeader: forwards all headers/cookies/query strings
     # except Host. API Gateway's execute-api domain is itself fronted by AWS's shared
     # edge network, and forwarding the viewer's Host header (tally.kenhoward.dev, a
     # registered CloudFront alias) collides with that routing, causing
     # misdirected-request errors instead of reaching the Lambda backend.
-    origin_request_policy_id = "b689b0a8-53d0-40ab-baf2-68738e2966ac"
+    origin_request_policy_id = data.aws_cloudfront_origin_request_policy.all_viewer_except_host_header.id
   }
 
   aliases     = var.aliases

--- a/infra/modules/cloudfront/main.tf
+++ b/infra/modules/cloudfront/main.tf
@@ -51,21 +51,16 @@ resource "aws_cloudfront_distribution" "frontend" {
     cached_methods         = ["GET", "HEAD", "OPTIONS"]
     target_origin_id       = "api-gateway"
     viewer_protocol_policy = "redirect-to-https"
-    min_ttl                = 0
-    default_ttl            = 0
-    max_ttl                = 0
-    forwarded_values {
-      query_string = true
-      # Do not forward Host: API Gateway's execute-api domain is itself fronted by
-      # AWS's shared edge network, and forwarding the viewer's Host header (e.g. via
-      # a "*" wildcard) collides with tally.kenhoward.dev being a registered
-      # CloudFront alias, causing misrouted/misdirected-request errors instead of
-      # reaching the Lambda backend.
-      headers = ["Authorization", "Content-Type", "Accept"]
-      cookies {
-        forward = "all"
-      }
-    }
+
+    # Managed-CachingDisabled: this behavior proxies a live API, not cacheable content.
+    cache_policy_id = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad"
+
+    # Managed-AllViewerExceptHostHeader: forwards all headers/cookies/query strings
+    # except Host. API Gateway's execute-api domain is itself fronted by AWS's shared
+    # edge network, and forwarding the viewer's Host header (tally.kenhoward.dev, a
+    # registered CloudFront alias) collides with that routing, causing
+    # misdirected-request errors instead of reaching the Lambda backend.
+    origin_request_policy_id = "b689b0a8-53d0-40ab-baf2-68738e2966ac"
   }
 
   aliases     = var.aliases

--- a/infra/modules/cloudfront/main.tf
+++ b/infra/modules/cloudfront/main.tf
@@ -56,7 +56,12 @@ resource "aws_cloudfront_distribution" "frontend" {
     max_ttl                = 0
     forwarded_values {
       query_string = true
-      headers      = ["*"]
+      # Do not forward Host: API Gateway's execute-api domain is itself fronted by
+      # AWS's shared edge network, and forwarding the viewer's Host header (e.g. via
+      # a "*" wildcard) collides with tally.kenhoward.dev being a registered
+      # CloudFront alias, causing misrouted/misdirected-request errors instead of
+      # reaching the Lambda backend.
+      headers = ["Authorization", "Content-Type", "Accept"]
       cookies {
         forward = "all"
       }

--- a/infra/modules/cloudfront/variables.tf
+++ b/infra/modules/cloudfront/variables.tf
@@ -28,9 +28,20 @@ variable "api_path_pattern" {
 }
 
 variable "api_origin_path" {
-  description = "Path CloudFront prepends when forwarding to the API Gateway origin (e.g., /prod), since the origin's execute-api domain alone omits the stage."
+  description = "Path CloudFront prepends when forwarding to the API Gateway origin (e.g., /prod)."
   type        = string
   default     = ""
+
+  validation {
+    # CloudFront origin_path must be empty, or start with "/" and not end with "/"
+    # (a bare "/" fails both). substr() (not startswith()/endswith()) so this works
+    # on Terraform >= 1.0, matching the module's stated required_version.
+    condition = var.api_origin_path == "" || (
+      substr(var.api_origin_path, 0, 1) == "/" &&
+      substr(var.api_origin_path, -1, 1) != "/"
+    )
+    error_message = "api_origin_path must be empty, or start with \"/\" and not end with \"/\"."
+  }
 }
 
 variable "tags" {

--- a/infra/modules/cloudfront/variables.tf
+++ b/infra/modules/cloudfront/variables.tf
@@ -27,6 +27,12 @@ variable "api_path_pattern" {
   default     = "/api/v1/*"
 }
 
+variable "api_origin_path" {
+  description = "Path CloudFront prepends when forwarding to the API Gateway origin (e.g., /prod), since the origin's execute-api domain alone omits the stage."
+  type        = string
+  default     = ""
+}
+
 variable "tags" {
   description = "Tags to apply to CloudFront resources."
   type        = map(string)

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -43,6 +43,17 @@ variable "environment" {
   default     = "prod"
   # Set via environment variable TF_VAR_environment
   # GitHub Actions: Uses workflow inputs or defaults to production
+
+  validation {
+    # Only "prod" is supported today: infra/backend.conf hardcodes a single shared
+    # state key, and the CloudFront alias/ACM cert (infra/main.tf's frontend_domain)
+    # aren't environment-parameterized. A non-prod apply would reuse prod's state,
+    # force-replace the (immutable) API Gateway stage, and repoint the live prod
+    # CloudFront distribution instead of creating an isolated environment. Expand
+    # this list only after those pieces are also made environment-aware.
+    condition     = var.environment == "prod"
+    error_message = "environment must be \"prod\" - see the validation block comment for why other values aren't safe yet."
+  }
 }
 
 variable "database_url_readwrite" {


### PR DESCRIPTION
## Summary

While verifying #72/#74 actually fixed the outage, found that `tally.kenhoward.dev/api/v1/*` still didn't reach the backend even though the Lambda/API Gateway origin was independently healthy (confirmed via its direct invoke URL). This grew into four compounding fixes across the CloudFront `/api/v1/*` behavior and its surrounding config, all applied to prod and verified:

1. **Invalid header combination**: `forwarded_values.headers = ["*", "Authorization"]` combined the forward-all wildcard with an explicit header name - CloudFront's API accepts this at apply time but it's undefined at request time.
2. **Missing stage prefix**: the `api-gateway` custom origin had no `origin_path`, so CloudFront forwarded requests to the bare `execute-api` domain without the `/prod` stage segment, and API Gateway rejected every request with its own `403 ForbiddenException`.
3. **The actual blocker - Host header collision**: forwarding `"*"` also forwards the viewer's original `Host: tally.kenhoward.dev` header to the origin. Since `tally.kenhoward.dev` is a registered CloudFront alias, and API Gateway's `execute-api` endpoints are themselves fronted by AWS's shared edge network, that Host header collided with AWS's edge routing - confirmed by sending that exact Host header directly to the origin and getting back a CloudFront `421` ("distribution does not match the certificate").
4. **Environment-aware stage handling**: parameterized API Gateway's `stage_name` to `var.environment` (was hardcoded `"prod"`) so a future non-prod environment gets a matching stage automatically. Per Copilot review feedback, `api_gateway_domain_name` and `api_origin_path` are now derived robustly (`split("/", ...)[0]` and `"/${var.environment}"`) instead of string-replacing a hardcoded `"/prod"`, which would have left an invalid path-containing "domain name" for any non-prod environment.

**Also per Copilot review feedback**: replaced the manual header allowlist (`Authorization`, `Content-Type`, `Accept`) with CloudFront's managed `origin_request_policy_id` (`Managed-AllViewerExceptHostHeader`) and `cache_policy_id` (`Managed-CachingDisabled`) - AWS's recommended pattern for this exact scenario. Forwards everything except `Host` automatically, so nothing needs to be manually added later as the API grows (CORS preflight headers, tracing headers, etc.), and removes the mutually-exclusive legacy `forwarded_values`/TTL attributes.

## Test plan

- [x] `terraform plan` reviewed before each apply: isolated diffs, 0 destroys across all fixes
- [x] All fixes applied directly to prod and verified after each change
- [x] `https://tally.kenhoward.dev/api/v1/health` returns a genuine FastAPI `404 {"detail":"Not Found"}` (correct - app has no route registered at that path) instead of a CloudFront-level error
- [x] Confirmed the fix is isolated to the `/api/v1/*` behavior (control test against a non-matching path behaves as before)
- [x] Confirmed `terraform plan` shows no changes for the current prod environment after the `stage_name`/domain-derivation fix (no-op today, correctness fix for future environments)
- [x] Re-verified `/api/v1/health` still works after switching to managed cache/origin-request policies
