### PR TITLE
fix: normalize DATABASE_URL_READWRITE to the asyncpg driver

### DIFF
--- a/backend/src/core/config.py
+++ b/backend/src/core/config.py
@@ -1,3 +1,4 @@
+from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -11,6 +12,18 @@ class Settings(BaseSettings):
 
     auth0_domain: str = ""
     auth0_audience: str = ""
+
+    @field_validator("database_url_readwrite")
+    @classmethod
+    def _use_asyncpg_driver(cls, value: str) -> str:
+        # Neon's console (and most Postgres providers) hand out plain
+        # postgresql:// connection strings - create_async_engine needs the
+        # +asyncpg driver suffix or it falls back to psycopg2 (sync, and not
+        # even installed here). Normalize rather than relying on whoever sets
+        # the secret to remember to add the suffix themselves.
+        if value.startswith("postgresql://"):
+            return "postgresql+asyncpg://" + value.removeprefix("postgresql://")
+        return value
 
 
 settings = Settings()


### PR DESCRIPTION
## Summary
Production's `terraform-apply.yml` run failed at "Run DB Migrations": `ModuleNotFoundError: No module named 'psycopg2'` ([run 29143131321](https://github.com/kenhowardpdx/tally/actions/runs/29143131321)).

**Root cause**: `TALLY_DATABASE_URL_READWRITE` holds a plain `postgresql://` connection string — exactly the format Neon's console hands out (see `.secrets.example`) — but `create_async_engine()` needs the `+asyncpg` driver suffix, or SQLAlchemy falls back to `psycopg2` (sync, and not even installed here).

**Fix**: normalize the URL scheme in `Settings` rather than requiring the secret itself to be reformatted. The secret can stay exactly what Neon's console gives you.

## Test plan
- [x] Reproduced the exact failure locally: `DATABASE_URL_READWRITE="postgresql://..." poetry run alembic current` failed identically before this fix
- [x] Same command succeeds after the fix
- [x] `create_async_engine` confirmed to select the `asyncpg` driver for both plain `postgresql://` and already-suffixed `postgresql+asyncpg://` inputs (idempotent)
- [x] Full backend test suite passes (8/8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)