### PR TITLE
fix: translate sslmode/channel_binding query params for the asyncpg driver

### DIFF
--- a/backend/src/core/config.py
+++ b/backend/src/core/config.py
@@ -1,3 +1,5 @@
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
 from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -15,15 +17,30 @@ class Settings(BaseSettings):
 
     @field_validator("database_url_readwrite")
     @classmethod
-    def _use_asyncpg_driver(cls, value: str) -> str:
-        # Neon's console (and most Postgres providers) hand out plain
-        # postgresql:// connection strings - create_async_engine needs the
-        # +asyncpg driver suffix or it falls back to psycopg2 (sync, and not
-        # even installed here). Normalize rather than relying on whoever sets
-        # the secret to remember to add the suffix themselves.
-        if value.startswith("postgresql://"):
-            return "postgresql+asyncpg://" + value.removeprefix("postgresql://")
-        return value
+    def _normalize_for_asyncpg(cls, value: str) -> str:
+        # Neon's console (and most Postgres providers) hand out standard libpq-
+        # style connection strings - a few adjustments make them work with the
+        # asyncpg driver instead:
+        #   - scheme needs the +asyncpg suffix, or SQLAlchemy defaults to the
+        #     sync psycopg2 driver (not installed here).
+        #   - sslmode= is psycopg2/libpq's name for what asyncpg calls ssl= -
+        #     passed through verbatim, asyncpg's connect() rejects the
+        #     unrecognized "sslmode" kwarg outright.
+        #   - channel_binding= has no asyncpg equivalent at all (it negotiates
+        #     channel binding automatically as part of SCRAM auth) - same
+        #     unrecognized-kwarg rejection, so it just gets dropped.
+        parts = urlsplit(value)
+        scheme = "postgresql+asyncpg" if parts.scheme == "postgresql" else parts.scheme
+
+        query_params = [
+            ("ssl" if key == "sslmode" else key, val)
+            for key, val in parse_qsl(parts.query)
+            if key != "channel_binding"
+        ]
+
+        return urlunsplit(
+            (scheme, parts.netloc, parts.path, urlencode(query_params), parts.fragment)
+        )
 
 
 settings = Settings()

--- a/backend/src/core/config.py
+++ b/backend/src/core/config.py
@@ -34,7 +34,7 @@ class Settings(BaseSettings):
 
         query_params = [
             ("ssl" if key == "sslmode" else key, val)
-            for key, val in parse_qsl(parts.query)
+            for key, val in parse_qsl(parts.query, keep_blank_values=True)
             if key != "channel_binding"
         ]
 

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,0 +1,26 @@
+from src.core.config import Settings
+
+
+def test_normalizes_plain_postgresql_scheme_to_asyncpg():
+    settings = Settings(database_url_readwrite="postgresql://user:pass@host/db")
+    assert settings.database_url_readwrite == "postgresql+asyncpg://user:pass@host/db"
+
+
+def test_leaves_already_asyncpg_scheme_unchanged():
+    url = "postgresql+asyncpg://user:pass@host/db"
+    settings = Settings(database_url_readwrite=url)
+    assert settings.database_url_readwrite == url
+
+
+def test_translates_sslmode_to_ssl_and_drops_channel_binding():
+    # Exactly the shape Neon's console hands out - psycopg2/libpq query
+    # params that asyncpg's connect() doesn't accept as keyword arguments.
+    settings = Settings(
+        database_url_readwrite=(
+            "postgresql://user:pass@ep-example-pooler.neon.tech/db"
+            "?sslmode=require&channel_binding=require"
+        )
+    )
+    assert settings.database_url_readwrite == (
+        "postgresql+asyncpg://user:pass@ep-example-pooler.neon.tech/db?ssl=require"
+    )


### PR DESCRIPTION
## Summary
Merging #78 fixed the `psycopg2` issue but exposed the next one in the same deploy: `TypeError: connect() got an unexpected keyword argument 'sslmode'` ([run 29143381360](https://github.com/kenhowardpdx/tally/actions/runs/29143381360)).

**Root cause**: Neon's connection strings use libpq/psycopg2 query param names (`sslmode`, `channel_binding`) that `asyncpg`'s `connect()` doesn't recognize — it uses `ssl` instead, and negotiates channel binding automatically as part of SCRAM auth with no configurable equivalent. SQLAlchemy's asyncpg dialect passes query params straight through as `connect()` kwargs, so an unrecognized name is a hard `TypeError`, not a silent ignore.

**Fix**: translate `sslmode=X` → `ssl=X` and drop `channel_binding` entirely in the same `Settings` validator that already handles the driver-scheme normalization from #78.

## Test plan
- [x] Reproduced the exact failure locally against Postgres: `?sslmode=...&channel_binding=...` throws the identical `TypeError`
- [x] Confirmed the fix's translated `?ssl=...` connects successfully end-to-end (real connection + query) through `src/core/database.py`'s actual engine
- [x] `alembic upgrade head`/`current` succeed with the translated URL — the exact command that was failing in CI
- [x] Added unit tests for the translation logic (3 new, 11/11 total passing)