### PR TITLE
fix: deploy-frontend job couldn't see environment-scoped Auth0 secrets

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -23,6 +23,11 @@ on:
 jobs:
   deploy-frontend:
     runs-on: ubuntu-latest
+    # Needed to access environment-scoped secrets (TALLY_AUTH0_*) - without
+    # this, secrets.TALLY_AUTH0_* silently resolve to empty strings rather
+    # than erroring, which is exactly what shipped a build with an empty
+    # Auth0 domain/client_id/audience baked into the static site.
+    environment: ${{ github.event.inputs.environment || 'prod' }}
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary
The live site's login button redirects to `https://authorize/?client_id=&...&audience=&...` — empty `client_id`/`audience`, and the domain itself collapsed into `authorize` (from `https://${domain}/authorize` with an empty domain).

**Root cause**: `TALLY_AUTH0_DOMAIN`/`CLIENT_ID`/`AUDIENCE` are scoped to the `prod` GitHub Environment (confirmed via `gh secret list --env prod`), but `deploy-frontend.yml`'s job never declared `environment:`, unlike `terraform-apply.yml`'s job which does. Without it, `secrets.TALLY_AUTH0_*` silently resolve to empty strings instead of erroring — and since this is a static site, that got baked permanently into the deployed build.

**Fix**: add `environment: ${{ github.event.inputs.environment || 'prod' }}` to the job, matching the pattern already used in `terraform-apply.yml`.

## Next step after merge
This alone won't fix the live site — `deploy-frontend.yml` only triggers on `frontend/**` path changes, and this PR only touches the workflow file, so it won't auto-fire. After merging, the frontend needs a manual rebuild (`workflow_dispatch`) to actually bake in the now-visible secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)