### PR TITLE
fix: invalidate CloudFront cache after each frontend deploy

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -88,3 +88,14 @@ jobs:
             exit 1
           fi
           aws s3 sync . s3://$bucket_name/ --region "$AWS_REGION" --delete || { echo "❌ S3 sync failed."; exit 1; }
+
+      - name: Invalidate CloudFront Cache
+        run: |
+          distribution_id=$(aws cloudfront list-distributions \
+            --query "DistributionList.Items[?contains(Aliases.Items, 'tally.kenhoward.dev')].Id" \
+            --output text)
+          if [ -z "$distribution_id" ]; then
+            echo "❌ No matching CloudFront distribution found."
+            exit 1
+          fi
+          aws cloudfront create-invalidation --distribution-id "$distribution_id" --paths "/*"

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -91,11 +91,19 @@ jobs:
 
       - name: Invalidate CloudFront Cache
         run: |
-          distribution_id=$(aws cloudfront list-distributions \
-            --query "DistributionList.Items[?contains(Aliases.Items, 'tally.kenhoward.dev')].Id" \
+          alias="tally.kenhoward.dev"
+          distribution_ids=$(aws cloudfront list-distributions \
+            --query "DistributionList.Items[?Aliases.Items && contains(Aliases.Items, '${alias}')].Id" \
             --output text)
-          if [ -z "$distribution_id" ]; then
-            echo "❌ No matching CloudFront distribution found."
+
+          # Ensure we got exactly one match (AWS CLI text output is whitespace-separated)
+          set -- $distribution_ids
+          if [ $# -eq 0 ]; then
+            echo "❌ No matching CloudFront distribution found for alias: ${alias}"
+            exit 1
+          elif [ $# -gt 1 ]; then
+            echo "❌ Multiple CloudFront distributions matched alias ${alias}: ${distribution_ids}"
             exit 1
           fi
-          aws cloudfront create-invalidation --distribution-id "$distribution_id" --paths "/*"
+
+          aws cloudfront create-invalidation --distribution-id "$1" --paths "/*"


### PR DESCRIPTION
## Summary
The Auth0 domain fix (#80) actually built and deployed correctly — confirmed via the "Build Assets" step logs (`PUBLIC_AUTH0_*` all showed masked/non-empty values that run). But the live site kept showing the exact same broken behavior.

`curl -sI https://tally.kenhoward.dev/` explained why: `x-cache: Hit from cloudfront`, `age: 797`. CloudFront was still serving the *previous* (broken) build from cache. This workflow syncs new files to S3 but never invalidates the CloudFront distribution sitting in front of it — every deploy has been invisible until the cache naturally expires.

## Fix
Added a CloudFront invalidation step after the S3 sync, dynamically looking up the distribution by its alias (matching the existing pattern used to find the S3 bucket by name prefix — no hardcoded IDs).

## ⚠️ Possible follow-up needed
The GitHub Actions IAM role (`AWS_ROLE_ARN`) isn't managed in this repo — it's referenced only as an ARN variable, created outside Terraform/version control. I can't verify from here whether it already has the needed permissions. **If this step fails with `AccessDenied`**, that role's IAM policy needs:
```json
{
  "Effect": "Allow",
  "Action": ["cloudfront:ListDistributions", "cloudfront:CreateInvalidation"],
  "Resource": "*"
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)