### PR TITLE
Phase 1 follow-ups: bills header, move-bill UI, Select/DatePicker/Frequency polish

### DIFF
--- a/backend/src/api/bills.py
+++ b/backend/src/api/bills.py
@@ -2,9 +2,9 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.api.deps import get_owned_bank_account
+from src.api.deps import get_bank_account_or_404, get_current_db_user, get_owned_bank_account
 from src.core.database import get_db
-from src.models import BankAccount, Bill
+from src.models import BankAccount, Bill, User
 from src.schemas.bill import BillCreate, BillRead, BillUpdate
 
 router = APIRouter(prefix="/api/v1/accounts/{account_id}/bills", tags=["bills"])
@@ -51,8 +51,16 @@ async def update_bill(
     payload: BillUpdate,
     db: AsyncSession = Depends(get_db),
     bill: Bill = Depends(_get_owned_bill),
+    current_user: User = Depends(get_current_db_user),
 ) -> Bill:
-    for field, value in payload.model_dump(exclude_unset=True).items():
+    update_data = payload.model_dump(exclude_unset=True)
+    if "account_id" in update_data:
+        # Moving a bill to another account - the target must also belong to
+        # the current user, same as the account this route is already
+        # scoped to (get_owned_bank_account only validated the *current*
+        # account_id from the URL, not the new one in the body).
+        await get_bank_account_or_404(update_data["account_id"], db, current_user)
+    for field, value in update_data.items():
         setattr(bill, field, value)
     await db.commit()
     await db.refresh(bill)

--- a/backend/src/api/deps.py
+++ b/backend/src/api/deps.py
@@ -29,10 +29,8 @@ async def get_current_db_user(
     return user
 
 
-async def get_owned_bank_account(
-    account_id: int,
-    db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_db_user),
+async def get_bank_account_or_404(
+    account_id: int, db: AsyncSession, current_user: User
 ) -> BankAccount:
     result = await db.execute(
         select(BankAccount).where(
@@ -43,3 +41,11 @@ async def get_owned_bank_account(
     if account is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Account not found")
     return account
+
+
+async def get_owned_bank_account(
+    account_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_db_user),
+) -> BankAccount:
+    return await get_bank_account_or_404(account_id, db, current_user)

--- a/backend/src/schemas/bill.py
+++ b/backend/src/schemas/bill.py
@@ -23,6 +23,7 @@ class BillUpdate(BaseModel):
     start_date: date | None = None
     end_date: date | None = None
     enabled: bool | None = None
+    account_id: int | None = None
 
 
 class BillRead(BaseModel):

--- a/backend/tests/test_bills_api.py
+++ b/backend/tests/test_bills_api.py
@@ -74,6 +74,43 @@ async def test_delete_bill(client: AsyncClient):
     assert res.json() == []
 
 
+async def test_move_bill_to_another_owned_account(client: AsyncClient):
+    account_a = await _create_account(client)
+    account_b = (await client.post("/api/v1/accounts", json={"name": "Savings"})).json()
+    bill = (
+        await client.post(f"/api/v1/accounts/{account_a['id']}/bills", json=_bill_payload())
+    ).json()
+
+    res = await client.patch(
+        f"/api/v1/accounts/{account_a['id']}/bills/{bill['id']}",
+        json={"account_id": account_b["id"]},
+    )
+    assert res.status_code == 200
+    assert res.json()["account_id"] == account_b["id"]
+
+    res = await client.get(f"/api/v1/accounts/{account_a['id']}/bills")
+    assert res.json() == []
+    res = await client.get(f"/api/v1/accounts/{account_b['id']}/bills")
+    assert len(res.json()) == 1
+
+
+async def test_cannot_move_bill_to_another_users_account(client: AsyncClient):
+    account = await _create_account(client)
+    bill = (
+        await client.post(f"/api/v1/accounts/{account['id']}/bills", json=_bill_payload())
+    ).json()
+
+    _login_as("auth0|someone-else")
+    other_account = (await client.post("/api/v1/accounts", json={"name": "Their account"})).json()
+    _login_as("auth0|owner")
+
+    res = await client.patch(
+        f"/api/v1/accounts/{account['id']}/bills/{bill['id']}",
+        json={"account_id": other_account["id"]},
+    )
+    assert res.status_code == 404
+
+
 async def test_bills_scoped_to_account_owner(client: AsyncClient):
     account = await _create_account(client)
     await client.post(f"/api/v1/accounts/{account['id']}/bills", json=_bill_payload())

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -164,7 +164,7 @@ per-PR preview branch) make manual Neon console clicks a recurring chore.
 
 ## Phase 1 — Accounts & Bills CRUD
 
-**Status**: code complete; three follow-up items below
+**Status**: code complete; one follow-up item below (1.7, not yet scoped)
 
 - [x] 1.1 Backend: `bank_accounts` CRUD API, scoped to the authenticated user
 - [x] 1.2 Backend: `bills` CRUD API, scoped to an account, including the enable/disable
@@ -172,12 +172,12 @@ per-PR preview branch) make manual Neon console clicks a recurring chore.
 - [x] 1.3 Frontend: accounts list/management page
 - [x] 1.4 Frontend: bills list/management page per account (Svelte equivalent of
       `clientv0`'s `Bills.tsx` editable table UX)
-- [ ] 1.5 Bills page header always reads "Bills" regardless of which account you're on —
+- [x] 1.5 Bills page header always reads "Bills" regardless of which account you're on —
       should read `Bills (<Name> - <Bank>)`. Backend already exposes
       `GET /api/v1/accounts/{id}`; frontend just needs a `getAccount` call added to
       `frontend/src/lib/api/accounts.ts` and used in
       `frontend/src/routes/(app)/accounts/[id]/+page.svelte`.
-- [ ] 1.6 Move a bill to a different bank account. Backend: extend `BillUpdate`/
+- [x] 1.6 Move a bill to a different bank account. Backend: extend `BillUpdate`/
       `PATCH .../bills/{id}` (`backend/src/schemas/bill.py`, `backend/src/api/bills.py`) to
       accept a target `account_id`, verifying the target account also belongs to the
       current user (same ownership check pattern as `get_owned_bank_account`). Frontend: an
@@ -225,18 +225,16 @@ per-PR preview branch) make manual Neon console clicks a recurring chore.
 **Status**: not started
 
 - [ ] 4.1 Dashboard aggregating all of a user's accounts (combined + per-account views)
-- [ ] 4.2 UI/design pass — consistent Svelte component system, responsive layout, including:
-      - a real date-picker component (the native `<input type="date">` used in the bill form
-        at `frontend/src/routes/(app)/accounts/[id]/+page.svelte` works but looks/behaves
-        inconsistently across browsers)
-      - a `Select` component styled to match `Input` (`frontend/src/lib/components/`) — the
-        recurrence `<select>` in the bill form currently has its own one-off Tailwind classes
-      - rename the "Recurrence" label to "Frequency" in the bill form (same field/enum on the
-        backend — `recurrence_type` — this is a UI copy change only)
-      - human-readable labels for recurrence values in the dropdown and the bills table — no
-        mapping exists today, so raw enum values render as-is (e.g. `custom_days` shows
-        literally as "custom_days" at
-        `frontend/src/routes/(app)/accounts/[id]/+page.svelte:112,142`)
+- [ ] 4.2 UI/design pass — consistent Svelte component system, responsive layout. Still open:
+      general responsive layout pass, plus whatever else turns up. Done so far:
+      - [x] a real date-picker component (`frontend/src/lib/components/DatePicker.svelte`,
+        a popover calendar) replacing the native `<input type="date">` in the bill form
+      - [x] a `Select` component styled to match `Input`
+        (`frontend/src/lib/components/Select.svelte`), used for the bill form's Frequency
+        field and the move-bill account picker
+      - [x] renamed the "Recurrence" label to "Frequency" in the bill form
+      - [x] human-readable labels for recurrence values (`frontend/src/lib/recurrence.ts`),
+        used in both the dropdown and the bills table
 - [ ] 4.3 Error handling, loading states, empty states throughout
 - [ ] 4.4 Test coverage: forecast engine (pytest), key frontend components
 
@@ -274,3 +272,9 @@ session (or a fresh Claude Code instance) orient in under a minute.
   name/bank (1.5), no way to move a bill between accounts (1.6), and the native date picker
   needs replacing (folded into 4.2). Next: pick up Phase 1.5/1.6, or start Phase 2
   (forecast engine).
+- 2026-07-11: Picked up 1.5, 1.6, and part of 4.2. Bills page header now shows
+  `Bills (<Name> - <Bank>)`; bills can be moved between accounts via a modal (backend
+  ownership-checks the target account); new `Select`, `Modal`, and `DatePicker` (custom
+  popover calendar, no new dependency) components; "Recurrence" renamed to "Frequency" with
+  human-readable value labels everywhere. Left 1.7 alone (recurrence-config UI) per its own
+  "not yet designed" flag. Next: scope 1.7, or start Phase 2.

--- a/frontend/src/lib/api/accounts.ts
+++ b/frontend/src/lib/api/accounts.ts
@@ -5,6 +5,10 @@ export function listAccounts(): Promise<BankAccount[]> {
 	return apiJson('/api/v1/accounts');
 }
 
+export function getAccount(id: number): Promise<BankAccount> {
+	return apiJson(`/api/v1/accounts/${id}`);
+}
+
 export function createAccount(input: BankAccountInput): Promise<BankAccount> {
 	return apiJson('/api/v1/accounts', { method: 'POST', body: JSON.stringify(input) });
 }

--- a/frontend/src/lib/api/bills.ts
+++ b/frontend/src/lib/api/bills.ts
@@ -15,7 +15,7 @@ export function createBill(accountId: number, input: BillInput): Promise<Bill> {
 export function updateBill(
 	accountId: number,
 	billId: number,
-	input: Partial<BillInput>
+	input: Partial<BillInput> & { account_id?: number }
 ): Promise<Bill> {
 	return apiJson(`/api/v1/accounts/${accountId}/bills/${billId}`, {
 		method: 'PATCH',

--- a/frontend/src/lib/components/DatePicker.svelte
+++ b/frontend/src/lib/components/DatePicker.svelte
@@ -101,6 +101,8 @@
 		type="button"
 		id={inputId}
 		onclick={() => (open = !open)}
+		aria-haspopup="dialog"
+		aria-expanded={open}
 		class="rounded-card border border-slate-300 px-3 py-2 text-left text-sm text-text focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
 	>
 		{value || 'Select date'}
@@ -109,6 +111,8 @@
 	{#if open}
 		<div
 			class="absolute top-full z-10 mt-1 w-64 rounded-card border border-slate-200 bg-surface p-3 shadow-card"
+			role="dialog"
+			aria-label="Choose date"
 		>
 			<div class="mb-2 flex items-center justify-between">
 				<button

--- a/frontend/src/lib/components/DatePicker.svelte
+++ b/frontend/src/lib/components/DatePicker.svelte
@@ -1,0 +1,158 @@
+<script lang="ts">
+	let {
+		label,
+		value = $bindable(''),
+		id
+	}: {
+		label?: string;
+		value?: string;
+		id?: string;
+	} = $props();
+
+	const inputId = id ?? label?.toLowerCase().replace(/\s+/g, '-');
+	const weekdayLabels = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
+
+	let open = $state(false);
+	let containerEl = $state<HTMLDivElement | undefined>();
+
+	function parseISO(iso: string): Date | null {
+		if (!iso) return null;
+		const [y, m, d] = iso.split('-').map(Number);
+		if (!y || !m || !d) return null;
+		return new Date(y, m - 1, d);
+	}
+
+	function toISO(date: Date): string {
+		const y = date.getFullYear();
+		const m = String(date.getMonth() + 1).padStart(2, '0');
+		const d = String(date.getDate()).padStart(2, '0');
+		return `${y}-${m}-${d}`;
+	}
+
+	function isSameDay(a: Date | null, b: Date | null): boolean {
+		return (
+			!!a &&
+			!!b &&
+			a.getFullYear() === b.getFullYear() &&
+			a.getMonth() === b.getMonth() &&
+			a.getDate() === b.getDate()
+		);
+	}
+
+	const selected = $derived(parseISO(value));
+
+	let viewDate = $state(new Date());
+
+	$effect(() => {
+		if (selected) viewDate = new Date(selected.getFullYear(), selected.getMonth(), 1);
+	});
+
+	const monthLabel = $derived(
+		viewDate.toLocaleDateString(undefined, { month: 'long', year: 'numeric' })
+	);
+
+	const weeks = $derived.by(() => {
+		const year = viewDate.getFullYear();
+		const month = viewDate.getMonth();
+		const startOffset = new Date(year, month, 1).getDay();
+		const daysInMonth = new Date(year, month + 1, 0).getDate();
+
+		const cells: (Date | null)[] = [];
+		for (let i = 0; i < startOffset; i++) cells.push(null);
+		for (let d = 1; d <= daysInMonth; d++) cells.push(new Date(year, month, d));
+		while (cells.length % 7 !== 0) cells.push(null);
+
+		const result: (Date | null)[][] = [];
+		for (let i = 0; i < cells.length; i += 7) result.push(cells.slice(i, i + 7));
+		return result;
+	});
+
+	function pick(date: Date) {
+		value = toISO(date);
+		open = false;
+	}
+
+	function prevMonth() {
+		viewDate = new Date(viewDate.getFullYear(), viewDate.getMonth() - 1, 1);
+	}
+
+	function nextMonth() {
+		viewDate = new Date(viewDate.getFullYear(), viewDate.getMonth() + 1, 1);
+	}
+
+	function handleWindowClick(event: MouseEvent) {
+		if (open && containerEl && !containerEl.contains(event.target as Node)) {
+			open = false;
+		}
+	}
+
+	function handleKeydown(event: KeyboardEvent) {
+		if (event.key === 'Escape') open = false;
+	}
+</script>
+
+<svelte:window onclick={handleWindowClick} onkeydown={open ? handleKeydown : undefined} />
+
+<div class="relative flex flex-col gap-1" bind:this={containerEl}>
+	{#if label}
+		<label for={inputId} class="text-sm font-medium text-text">{label}</label>
+	{/if}
+	<button
+		type="button"
+		id={inputId}
+		onclick={() => (open = !open)}
+		class="rounded-card border border-slate-300 px-3 py-2 text-left text-sm text-text focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+	>
+		{value || 'Select date'}
+	</button>
+
+	{#if open}
+		<div
+			class="absolute top-full z-10 mt-1 w-64 rounded-card border border-slate-200 bg-surface p-3 shadow-card"
+		>
+			<div class="mb-2 flex items-center justify-between">
+				<button
+					type="button"
+					onclick={prevMonth}
+					class="rounded px-2 py-1 text-sm text-slate-500 hover:bg-slate-100"
+					aria-label="Previous month"
+				>
+					‹
+				</button>
+				<span class="text-sm font-medium text-text">{monthLabel}</span>
+				<button
+					type="button"
+					onclick={nextMonth}
+					class="rounded px-2 py-1 text-sm text-slate-500 hover:bg-slate-100"
+					aria-label="Next month"
+				>
+					›
+				</button>
+			</div>
+			<div class="grid grid-cols-7 gap-1 text-center text-xs text-slate-400">
+				{#each weekdayLabels as day, i (i)}
+					<span>{day}</span>
+				{/each}
+			</div>
+			{#each weeks as week, weekIndex (weekIndex)}
+				<div class="grid grid-cols-7 gap-1">
+					{#each week as day, dayIndex (dayIndex)}
+						{#if day}
+							<button
+								type="button"
+								onclick={() => pick(day)}
+								class="rounded px-1 py-1 text-sm hover:bg-slate-100 {isSameDay(day, selected)
+									? 'bg-primary text-white hover:bg-primary/90'
+									: 'text-text'}"
+							>
+								{day.getDate()}
+							</button>
+						{:else}
+							<span></span>
+						{/if}
+					{/each}
+				</div>
+			{/each}
+		</div>
+	{/if}
+</div>

--- a/frontend/src/lib/components/Modal.svelte
+++ b/frontend/src/lib/components/Modal.svelte
@@ -11,6 +11,9 @@
 		children: Snippet;
 	} = $props();
 
+	const uid = $props.id();
+	const titleId = `${uid}-title`;
+
 	function close() {
 		open = false;
 	}
@@ -39,11 +42,11 @@
 			role="dialog"
 			tabindex="-1"
 			aria-modal="true"
-			aria-label={title}
+			aria-labelledby={title ? titleId : undefined}
 		>
 			<div class="mb-4 flex items-center justify-between">
 				{#if title}
-					<h2 class="text-lg font-semibold text-text">{title}</h2>
+					<h2 id={titleId} class="text-lg font-semibold text-text">{title}</h2>
 				{/if}
 				<button
 					type="button"

--- a/frontend/src/lib/components/Modal.svelte
+++ b/frontend/src/lib/components/Modal.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	let {
+		open = $bindable(false),
+		title,
+		children
+	}: {
+		open?: boolean;
+		title?: string;
+		children: Snippet;
+	} = $props();
+
+	function close() {
+		open = false;
+	}
+
+	function handleKeydown(event: KeyboardEvent) {
+		if (event.key === 'Escape') close();
+	}
+
+	function handleBackdropClick(event: MouseEvent) {
+		// Only the backdrop itself should close - clicks inside the dialog
+		// bubble up here too, but their target won't be currentTarget.
+		if (event.target === event.currentTarget) close();
+	}
+</script>
+
+<svelte:window onkeydown={open ? handleKeydown : undefined} />
+
+{#if open}
+	<div
+		class="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+		onclick={handleBackdropClick}
+		role="presentation"
+	>
+		<div
+			class="w-full max-w-sm rounded-card bg-surface p-6 shadow-card"
+			role="dialog"
+			tabindex="-1"
+			aria-modal="true"
+			aria-label={title}
+		>
+			<div class="mb-4 flex items-center justify-between">
+				{#if title}
+					<h2 class="text-lg font-semibold text-text">{title}</h2>
+				{/if}
+				<button
+					type="button"
+					class="text-slate-500 hover:text-text"
+					onclick={close}
+					aria-label="Close"
+				>
+					✕
+				</button>
+			</div>
+			{@render children()}
+		</div>
+	</div>
+{/if}

--- a/frontend/src/lib/components/Select.svelte
+++ b/frontend/src/lib/components/Select.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	let {
+		label,
+		value = $bindable(''),
+		id,
+		required = false,
+		children
+	}: {
+		label?: string;
+		value?: string;
+		id?: string;
+		required?: boolean;
+		children: Snippet;
+	} = $props();
+
+	const selectId = id ?? label?.toLowerCase().replace(/\s+/g, '-');
+</script>
+
+<div class="flex flex-col gap-1">
+	{#if label}
+		<label for={selectId} class="text-sm font-medium text-text">{label}</label>
+	{/if}
+	<select
+		id={selectId}
+		{required}
+		bind:value
+		class="rounded-card border border-slate-300 px-3 py-2 text-sm text-text focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+	>
+		{@render children()}
+	</select>
+</div>

--- a/frontend/src/lib/recurrence.ts
+++ b/frontend/src/lib/recurrence.ts
@@ -1,0 +1,10 @@
+import type { RecurrenceType } from '$lib/api/types';
+
+export const recurrenceLabels: Record<RecurrenceType, string> = {
+	weekly: 'Weekly',
+	biweekly: 'Biweekly',
+	semimonthly: 'Semimonthly',
+	monthly: 'Monthly',
+	annually: 'Annually',
+	custom_days: 'Custom (days)'
+};

--- a/frontend/src/routes/(app)/accounts/[id]/+page.svelte
+++ b/frontend/src/routes/(app)/accounts/[id]/+page.svelte
@@ -42,15 +42,23 @@
 	let moving = $state(false);
 	let showMoveModal = $state(false);
 
-	async function load() {
+	// Account details and the accounts list (for the move-bill picker) only
+	// change when navigating here or moving a bill elsewhere entirely - they
+	// don't need refetching after every bill create/toggle/delete, unlike
+	// bills itself.
+	async function loadContext() {
+		try {
+			[account, accounts] = await Promise.all([getAccount(accountId), listAccounts()]);
+		} catch (err) {
+			error = err instanceof Error ? err.message : String(err);
+		}
+	}
+
+	async function loadBills() {
 		loading = true;
 		error = null;
 		try {
-			[account, bills, accounts] = await Promise.all([
-				getAccount(accountId),
-				listBills(accountId),
-				listAccounts()
-			]);
+			bills = await listBills(accountId);
 		} catch (err) {
 			error = err instanceof Error ? err.message : String(err);
 		} finally {
@@ -58,7 +66,10 @@
 		}
 	}
 
-	onMount(load);
+	onMount(() => {
+		loadContext();
+		loadBills();
+	});
 
 	async function handleCreate(event: SubmitEvent) {
 		event.preventDefault();
@@ -75,7 +86,7 @@
 			name = '';
 			amount = '';
 			startDate = '';
-			await load();
+			await loadBills();
 		} catch (err) {
 			error = err instanceof Error ? err.message : String(err);
 		} finally {
@@ -86,7 +97,7 @@
 	async function toggleEnabled(bill: Bill) {
 		try {
 			await updateBill(accountId, bill.id, { enabled: !bill.enabled });
-			await load();
+			await loadBills();
 		} catch (err) {
 			error = err instanceof Error ? err.message : String(err);
 		}
@@ -95,7 +106,7 @@
 	async function handleDelete(billId: number) {
 		try {
 			await deleteBill(accountId, billId);
-			await load();
+			await loadBills();
 		} catch (err) {
 			error = err instanceof Error ? err.message : String(err);
 		}
@@ -114,7 +125,7 @@
 		try {
 			await updateBill(accountId, movingBill.id, { account_id: Number(moveTargetAccountId) });
 			showMoveModal = false;
-			await load();
+			await loadBills();
 		} catch (err) {
 			error = err instanceof Error ? err.message : String(err);
 		} finally {

--- a/frontend/src/routes/(app)/accounts/[id]/+page.svelte
+++ b/frontend/src/routes/(app)/accounts/[id]/+page.svelte
@@ -1,12 +1,17 @@
 <script lang="ts">
 	import { page } from '$app/stores';
+	import { getAccount, listAccounts } from '$lib/api/accounts';
 	import { createBill, deleteBill, listBills, updateBill } from '$lib/api/bills';
-	import type { Bill, RecurrenceType } from '$lib/api/types';
+	import type { BankAccount, Bill, RecurrenceType } from '$lib/api/types';
 	import Badge from '$lib/components/Badge.svelte';
 	import Button from '$lib/components/Button.svelte';
 	import Card from '$lib/components/Card.svelte';
+	import DatePicker from '$lib/components/DatePicker.svelte';
 	import Input from '$lib/components/Input.svelte';
+	import Modal from '$lib/components/Modal.svelte';
+	import Select from '$lib/components/Select.svelte';
 	import Table from '$lib/components/Table.svelte';
+	import { recurrenceLabels } from '$lib/recurrence';
 	import { onMount } from 'svelte';
 
 	const accountId = $derived(Number($page.params.id));
@@ -20,6 +25,8 @@
 		'custom_days'
 	];
 
+	let account = $state<BankAccount | null>(null);
+	let accounts = $state<BankAccount[]>([]);
 	let bills = $state<Bill[]>([]);
 	let loading = $state(true);
 	let error = $state<string | null>(null);
@@ -30,11 +37,20 @@
 	let startDate = $state('');
 	let creating = $state(false);
 
+	let movingBill = $state<Bill | null>(null);
+	let moveTargetAccountId = $state('');
+	let moving = $state(false);
+	let showMoveModal = $state(false);
+
 	async function load() {
 		loading = true;
 		error = null;
 		try {
-			bills = await listBills(accountId);
+			[account, bills, accounts] = await Promise.all([
+				getAccount(accountId),
+				listBills(accountId),
+				listAccounts()
+			]);
 		} catch (err) {
 			error = err instanceof Error ? err.message : String(err);
 		} finally {
@@ -85,13 +101,36 @@
 		}
 	}
 
+	function openMoveModal(bill: Bill) {
+		movingBill = bill;
+		moveTargetAccountId = '';
+		showMoveModal = true;
+	}
+
+	async function handleMove(event: SubmitEvent) {
+		event.preventDefault();
+		if (!movingBill || !moveTargetAccountId) return;
+		moving = true;
+		try {
+			await updateBill(accountId, movingBill.id, { account_id: Number(moveTargetAccountId) });
+			showMoveModal = false;
+			await load();
+		} catch (err) {
+			error = err instanceof Error ? err.message : String(err);
+		} finally {
+			moving = false;
+		}
+	}
+
 	function formatAmount(cents: number): string {
 		return (cents / 100).toLocaleString(undefined, { style: 'currency', currency: 'USD' });
 	}
 </script>
 
 <a class="text-sm text-primary underline" href="/accounts">&larr; Accounts</a>
-<h1 class="mt-2 text-2xl font-semibold text-text">Bills</h1>
+<h1 class="mt-2 text-2xl font-semibold text-text">
+	Bills{#if account} ({account.name}{#if account.institution} - {account.institution}{/if}){/if}
+</h1>
 
 {#if error}
 	<p class="mt-4 rounded-card bg-red-50 px-4 py-2 text-sm text-red-700">{error}</p>
@@ -101,19 +140,12 @@
 	<form class="flex flex-wrap items-end gap-4" onsubmit={handleCreate}>
 		<Input label="Name" bind:value={name} placeholder="Rent" required />
 		<Input label="Amount ($)" type="number" bind:value={amount} placeholder="1500.00" required />
-		<div class="flex flex-col gap-1">
-			<label for="recurrence" class="text-sm font-medium text-text">Recurrence</label>
-			<select
-				id="recurrence"
-				bind:value={recurrenceType}
-				class="rounded-card border border-slate-300 px-3 py-2 text-sm text-text focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-			>
-				{#each recurrenceOptions as option (option)}
-					<option value={option}>{option}</option>
-				{/each}
-			</select>
-		</div>
-		<Input label="Start date" type="date" bind:value={startDate} required />
+		<Select label="Frequency" bind:value={recurrenceType}>
+			{#each recurrenceOptions as option (option)}
+				<option value={option}>{recurrenceLabels[option]}</option>
+			{/each}
+		</Select>
+		<DatePicker label="Start date" bind:value={startDate} />
 		<Button type="submit" disabled={creating}>Add bill</Button>
 	</form>
 </Card>
@@ -129,7 +161,7 @@
 				<tr class="border-b border-slate-200 text-xs uppercase text-slate-500">
 					<th class="px-4 py-2 font-medium">Name</th>
 					<th class="px-4 py-2 font-medium">Amount</th>
-					<th class="px-4 py-2 font-medium">Recurrence</th>
+					<th class="px-4 py-2 font-medium">Frequency</th>
 					<th class="px-4 py-2 font-medium">Status</th>
 					<th class="px-4 py-2"></th>
 				</tr>
@@ -139,14 +171,17 @@
 					<tr class="border-b border-slate-100 last:border-0">
 						<td class="px-4 py-2">{bill.name}</td>
 						<td class="px-4 py-2">{formatAmount(bill.amount_cents)}</td>
-						<td class="px-4 py-2 text-slate-600">{bill.recurrence_type}</td>
+						<td class="px-4 py-2 text-slate-600">{recurrenceLabels[bill.recurrence_type]}</td>
 						<td class="px-4 py-2">
 							<button onclick={() => toggleEnabled(bill)}>
 								<Badge enabled={bill.enabled} />
 							</button>
 						</td>
 						<td class="px-4 py-2 text-right">
-							<Button variant="danger" onclick={() => handleDelete(bill.id)}>Delete</Button>
+							<div class="flex justify-end gap-2">
+								<Button variant="secondary" onclick={() => openMoveModal(bill)}>Move</Button>
+								<Button variant="danger" onclick={() => handleDelete(bill.id)}>Delete</Button>
+							</div>
 						</td>
 					</tr>
 				{/each}
@@ -154,3 +189,25 @@
 		</Table>
 	{/if}
 </div>
+
+<Modal bind:open={showMoveModal} title="Move bill">
+	{#if movingBill}
+		<form class="flex flex-col gap-4" onsubmit={handleMove}>
+			<p class="text-sm text-slate-600">
+				Move <span class="font-medium text-text">{movingBill.name}</span> to a different account.
+			</p>
+			<Select label="Account" bind:value={moveTargetAccountId} required>
+				<option value="" disabled>Select an account</option>
+				{#each accounts.filter((a) => a.id !== accountId) as target (target.id)}
+					<option value={target.id}>{target.name}</option>
+				{/each}
+			</Select>
+			<div class="flex justify-end gap-2">
+				<Button variant="secondary" type="button" onclick={() => (showMoveModal = false)}>
+					Cancel
+				</Button>
+				<Button type="submit" disabled={moving || !moveTargetAccountId}>Move</Button>
+			</div>
+		</form>
+	{/if}
+</Modal>


### PR DESCRIPTION
## Summary

Picks up the three follow-up items logged after Phase 1 (#82) landed:

- **1.5** — the bills page header always read "Bills" regardless of account; now reads
  `Bills (<Name> - <Bank>)`.
- **1.6** — bills can now be moved to a different bank account via a modal (account
  picker); the backend validates the target account belongs to the current user before
  reassigning, and the bill drops out of the current list once moved.
- **Part of 4.2** — a `Select` component matching `Input`'s styling, a custom `DatePicker`
  popover-calendar component (no new dependency) replacing the native
  `<input type="date">`, the "Recurrence" label renamed to "Frequency", and human-readable
  labels for recurrence values everywhere they render (previously showed raw enum values
  like `custom_days`).

1.7 (recurrence-specific config UI) is intentionally **not** included — it's flagged in the
roadmap as not yet designed/scoped, so it's left for a dedicated pass.

## Test plan

- [x] `cd backend && poetry run pytest` — 22 passed (2 new: move-bill success + cross-user
      ownership rejection)
- [x] `cd frontend && yarn run check` — 0 errors, 0 warnings
- [x] `docker compose` dev server recompiles cleanly, no runtime errors in logs
- [x] Headless-browser pass: root page renders, `/accounts` redirects to the real Auth0
      tenant, zero console errors
- [ ] Manual click-through of the new Move-bill modal, Select/DatePicker styling, and
      Frequency labels — not done in this session (no login credentials available here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
