### PR TITLE
Phase 2: forecast engine (backend port, API, frontend view)

### DIFF
--- a/backend/alembic/versions/e6a7f75ee398_add_forecast_settings_to_bank_accounts.py
+++ b/backend/alembic/versions/e6a7f75ee398_add_forecast_settings_to_bank_accounts.py
@@ -1,0 +1,39 @@
+"""add forecast settings to bank_accounts
+
+Revision ID: e6a7f75ee398
+Revises: dce3073b2c4e
+Create Date: 2026-07-11 23:26:11.355961
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'e6a7f75ee398'
+down_revision: Union[str, Sequence[str], None] = 'dce3073b2c4e'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    cycle_type = sa.Enum('weekly', 'biweekly', 'monthly', 'semimonthly', name='cycle_type')
+    cycle_type.create(op.get_bind())
+    op.add_column('bank_accounts', sa.Column('forecast_starting_balance_cents', sa.BigInteger(), nullable=True))
+    op.add_column('bank_accounts', sa.Column('forecast_income_per_cycle_cents', sa.BigInteger(), nullable=True))
+    op.add_column('bank_accounts', sa.Column('forecast_cycle_type', cycle_type, nullable=True))
+    op.add_column('bank_accounts', sa.Column('forecast_start_date', sa.Date(), nullable=True))
+    op.add_column('bank_accounts', sa.Column('forecast_end_date', sa.Date(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('bank_accounts', 'forecast_end_date')
+    op.drop_column('bank_accounts', 'forecast_start_date')
+    op.drop_column('bank_accounts', 'forecast_cycle_type')
+    op.drop_column('bank_accounts', 'forecast_income_per_cycle_cents')
+    op.drop_column('bank_accounts', 'forecast_starting_balance_cents')
+    sa.Enum(name='cycle_type').drop(op.get_bind())

--- a/backend/src/api/forecast.py
+++ b/backend/src/api/forecast.py
@@ -1,0 +1,88 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.api.deps import get_owned_bank_account
+from src.core.database import get_db
+from src.forecast import ForecastBill, get_forecast
+from src.models import BankAccount, Bill
+from src.schemas.forecast import (
+    ForecastBillLine,
+    ForecastCycle,
+    ForecastRequest,
+    ForecastResponse,
+    UnscheduledBill,
+)
+
+router = APIRouter(prefix="/api/v1/accounts/{account_id}/forecast", tags=["forecast"])
+
+
+@router.post("", response_model=ForecastResponse)
+async def compute_forecast(
+    payload: ForecastRequest,
+    db: AsyncSession = Depends(get_db),
+    account: BankAccount = Depends(get_owned_bank_account),
+) -> ForecastResponse:
+    result = await db.execute(
+        select(Bill).where(Bill.account_id == account.id, Bill.enabled.is_(True))
+    )
+    forecast_bills = [
+        ForecastBill(
+            id=bill.id,
+            name=bill.name,
+            amount_cents=bill.amount_cents,
+            recurrence_type=bill.recurrence_type,
+            recurrence_config=bill.recurrence_config,
+            start_date=bill.start_date,
+            end_date=bill.end_date,
+        )
+        for bill in result.scalars().all()
+    ]
+
+    forecast = get_forecast(
+        forecast_bills,
+        payload.cycle_type,
+        payload.start_date,
+        payload.end_date,
+        payload.starting_balance_cents,
+        payload.income_per_cycle_cents,
+    )
+
+    # Persist as the account's last-used forecast settings (side effect of an
+    # otherwise read-only computation) so GET .../accounts/{id} reflects what
+    # was just run - revisiting the forecast page prefills the form with it
+    # instead of the user re-entering the same starting balance/dates every
+    # ~2-week pay cycle.
+    account.forecast_starting_balance_cents = payload.starting_balance_cents
+    account.forecast_income_per_cycle_cents = payload.income_per_cycle_cents
+    account.forecast_cycle_type = payload.cycle_type
+    account.forecast_start_date = payload.start_date
+    account.forecast_end_date = payload.end_date
+    await db.commit()
+
+    return ForecastResponse(
+        cycles=[
+            ForecastCycle(
+                start_date=cycle.start_date,
+                end_date=cycle.end_date,
+                bills=[
+                    ForecastBillLine(
+                        bill_id=line.bill_id,
+                        name=line.name,
+                        amount_cents=line.amount_cents,
+                        due_date=line.due_date,
+                    )
+                    for line in cycle.bills
+                ],
+                cycle_sum_cents=cycle.cycle_sum_cents,
+                running_balance_cents=cycle.running_balance_cents,
+            )
+            for cycle in forecast.cycles
+        ],
+        starting_balance_cents=forecast.starting_balance_cents,
+        ending_balance_cents=forecast.ending_balance_cents,
+        unscheduled_bills=[
+            UnscheduledBill(bill_id=bill.bill_id, name=bill.name, reason=bill.reason)
+            for bill in forecast.unscheduled_bills
+        ],
+    )

--- a/backend/src/forecast/__init__.py
+++ b/backend/src/forecast/__init__.py
@@ -1,0 +1,15 @@
+from src.forecast.bill import ForecastBill, MissingRecurrenceConfig
+from src.forecast.cycle import Cycle, CycleBillLine, build_cycle
+from src.forecast.engine import ForecastCycle, ForecastResult, UnscheduledBill, get_forecast
+
+__all__ = [
+    "Cycle",
+    "CycleBillLine",
+    "ForecastBill",
+    "ForecastCycle",
+    "ForecastResult",
+    "MissingRecurrenceConfig",
+    "UnscheduledBill",
+    "build_cycle",
+    "get_forecast",
+]

--- a/backend/src/forecast/bill.py
+++ b/backend/src/forecast/bill.py
@@ -45,8 +45,12 @@ def validate_recurrence_config(bill: ForecastBill) -> str | None:
     required for its recurrence_type, else None."""
     if bill.recurrence_type == RecurrenceType.SEMIMONTHLY:
         days = bill.recurrence_config.get("days")
-        if not isinstance(days, list) or not days or not all(isinstance(d, int) for d in days):
-            return "semimonthly bills need recurrence_config.days, e.g. [10, 25]"
+        if (
+            not isinstance(days, list)
+            or not days
+            or not all(isinstance(d, int) and 1 <= d <= 31 for d in days)
+        ):
+            return "semimonthly bills need recurrence_config.days as integers 1-31, e.g. [10, 25]"
     if bill.recurrence_type == RecurrenceType.CUSTOM_DAYS:
         interval = bill.recurrence_config.get("interval_days")
         if not isinstance(interval, int) or interval <= 0:

--- a/backend/src/forecast/bill.py
+++ b/backend/src/forecast/bill.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from calendar import monthrange
+from dataclasses import dataclass
+from datetime import date, timedelta
+
+from src.models.bill import RecurrenceType
+
+
+class MissingRecurrenceConfig(Exception):
+    """A bill's recurrence_type needs recurrence_config data that isn't set.
+
+    Raised for `semimonthly`/`custom_days` bills created before the UI to collect
+    that config exists (roadmap 1.7) - the forecast engine treats this as a
+    per-bill "can't be scheduled" condition, not a hard failure.
+    """
+
+
+@dataclass
+class ForecastBill:
+    """A bill, decoupled from the SQLAlchemy model so the engine has no ORM/DB
+    dependency and stays easy to unit test in isolation."""
+
+    id: int
+    name: str
+    amount_cents: int
+    recurrence_type: RecurrenceType
+    recurrence_config: dict
+    start_date: date
+    end_date: date | None
+
+
+def _last_day_of_month(year: int, month: int) -> int:
+    return monthrange(year, month)[1]
+
+
+def _clamp_day(year: int, month: int, day: int) -> int:
+    # A bill anchored on the 31st is due on the 28th/29th/30th in shorter
+    # months, rather than overflowing into the next month.
+    return min(day, _last_day_of_month(year, month))
+
+
+def validate_recurrence_config(bill: ForecastBill) -> str | None:
+    """Returns a human-readable reason if `bill.recurrence_config` is missing data
+    required for its recurrence_type, else None."""
+    if bill.recurrence_type == RecurrenceType.SEMIMONTHLY:
+        days = bill.recurrence_config.get("days")
+        if not isinstance(days, list) or not days or not all(isinstance(d, int) for d in days):
+            return "semimonthly bills need recurrence_config.days, e.g. [10, 25]"
+    if bill.recurrence_type == RecurrenceType.CUSTOM_DAYS:
+        interval = bill.recurrence_config.get("interval_days")
+        if not isinstance(interval, int) or interval <= 0:
+            return "custom_days bills need recurrence_config.interval_days"
+    return None
+
+
+def _within_bill_lifetime(bill: ForecastBill, occurrence: date) -> bool:
+    if occurrence < bill.start_date:
+        return False
+    if bill.end_date and occurrence > bill.end_date:
+        return False
+    return True
+
+
+def _monthly_occurrences(bill: ForecastBill, cycle_start: date, cycle_end: date) -> list[date]:
+    day = bill.start_date.day
+    occurrences = set()
+    for year, month in {(cycle_start.year, cycle_start.month), (cycle_end.year, cycle_end.month)}:
+        candidate = date(year, month, _clamp_day(year, month, day))
+        if cycle_start <= candidate <= cycle_end:
+            occurrences.add(candidate)
+    return sorted(occurrences)
+
+
+def _annually_occurrences(bill: ForecastBill, cycle_start: date, cycle_end: date) -> list[date]:
+    month, day = bill.start_date.month, bill.start_date.day
+    occurrences = set()
+    for year in {cycle_start.year, cycle_end.year}:
+        candidate = date(year, month, _clamp_day(year, month, day))
+        if cycle_start <= candidate <= cycle_end:
+            occurrences.add(candidate)
+    return sorted(occurrences)
+
+
+def _semimonthly_occurrences(bill: ForecastBill, cycle_start: date, cycle_end: date) -> list[date]:
+    days = bill.recurrence_config["days"]
+    occurrences = set()
+    for year, month in {(cycle_start.year, cycle_start.month), (cycle_end.year, cycle_end.month)}:
+        for day in days:
+            candidate = date(year, month, _clamp_day(year, month, day))
+            if cycle_start <= candidate <= cycle_end:
+                occurrences.add(candidate)
+    return sorted(occurrences)
+
+
+def _interval_occurrences(
+    anchor: date, interval_days: int, cycle_start: date, cycle_end: date
+) -> list[date]:
+    """All `anchor + k*interval_days` occurrences (k >= 0) landing in
+    [cycle_start, cycle_end]. Generalizes the reference's single-occurrence-per-
+    cycle model: a weekly bill inside a monthly cycle can genuinely recur more
+    than once in that window, and each occurrence should count."""
+    if cycle_end < anchor:
+        return []
+    effective_start = max(cycle_start, anchor)
+    offset_days = (effective_start - anchor).days
+    first_k = -(-offset_days // interval_days)  # ceil division
+
+    occurrences = []
+    k = first_k
+    while True:
+        candidate = anchor + timedelta(days=k * interval_days)
+        if candidate > cycle_end:
+            break
+        occurrences.append(candidate)
+        k += 1
+    return occurrences
+
+
+def occurrences_in_range(bill: ForecastBill, cycle_start: date, cycle_end: date) -> list[date]:
+    """All due-date occurrences of `bill` that fall within [cycle_start, cycle_end].
+
+    Raises MissingRecurrenceConfig if the bill's recurrence_type needs config data
+    that's absent - callers iterating many bills should pre-filter with
+    validate_recurrence_config instead of catching this per-call.
+    """
+    reason = validate_recurrence_config(bill)
+    if reason:
+        raise MissingRecurrenceConfig(reason)
+
+    if bill.recurrence_type == RecurrenceType.MONTHLY:
+        raw = _monthly_occurrences(bill, cycle_start, cycle_end)
+    elif bill.recurrence_type == RecurrenceType.ANNUALLY:
+        raw = _annually_occurrences(bill, cycle_start, cycle_end)
+    elif bill.recurrence_type == RecurrenceType.SEMIMONTHLY:
+        raw = _semimonthly_occurrences(bill, cycle_start, cycle_end)
+    elif bill.recurrence_type == RecurrenceType.WEEKLY:
+        raw = _interval_occurrences(bill.start_date, 7, cycle_start, cycle_end)
+    elif bill.recurrence_type == RecurrenceType.BIWEEKLY:
+        raw = _interval_occurrences(bill.start_date, 14, cycle_start, cycle_end)
+    elif bill.recurrence_type == RecurrenceType.CUSTOM_DAYS:
+        interval_days = bill.recurrence_config["interval_days"]
+        raw = _interval_occurrences(bill.start_date, interval_days, cycle_start, cycle_end)
+    else:  # pragma: no cover - exhaustive over RecurrenceType
+        raise ValueError(f"Unsupported recurrence type: {bill.recurrence_type}")
+
+    return [occurrence for occurrence in raw if _within_bill_lifetime(bill, occurrence)]

--- a/backend/src/forecast/cycle.py
+++ b/backend/src/forecast/cycle.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+
+from src.forecast.bill import ForecastBill, occurrences_in_range
+
+
+@dataclass
+class CycleBillLine:
+    bill_id: int
+    name: str
+    amount_cents: int
+    due_date: date
+
+
+@dataclass
+class Cycle:
+    bills: list[CycleBillLine]
+    sum_cents: int
+
+
+def build_cycle(bills: list[ForecastBill], start: date, end: date) -> Cycle:
+    """Bills due within [start, end], sorted by due date, with the total.
+
+    `bills` must already be pre-filtered to ones with valid recurrence_config
+    (see validate_recurrence_config) - this raises MissingRecurrenceConfig
+    otherwise, same as occurrences_in_range.
+    """
+    lines: list[CycleBillLine] = []
+    for bill in bills:
+        for occurrence in occurrences_in_range(bill, start, end):
+            lines.append(
+                CycleBillLine(
+                    bill_id=bill.id,
+                    name=bill.name,
+                    amount_cents=bill.amount_cents,
+                    due_date=occurrence,
+                )
+            )
+    lines.sort(key=lambda line: (line.due_date, line.bill_id))
+    total = sum(line.amount_cents for line in lines)
+    return Cycle(bills=lines, sum_cents=total)

--- a/backend/src/forecast/engine.py
+++ b/backend/src/forecast/engine.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from calendar import monthrange
+from dataclasses import dataclass
+from datetime import date, timedelta
+
+from src.forecast.bill import ForecastBill, validate_recurrence_config
+from src.forecast.cycle import CycleBillLine, build_cycle
+from src.models.bank_account import CycleType
+
+
+@dataclass
+class UnscheduledBill:
+    bill_id: int
+    name: str
+    reason: str
+
+
+@dataclass
+class ForecastCycle:
+    start_date: date
+    end_date: date
+    bills: list[CycleBillLine]
+    cycle_sum_cents: int
+    running_balance_cents: int
+
+
+@dataclass
+class ForecastResult:
+    cycles: list[ForecastCycle]
+    starting_balance_cents: int
+    ending_balance_cents: int
+    unscheduled_bills: list[UnscheduledBill]
+
+
+def _last_day_of_month(year: int, month: int) -> int:
+    return monthrange(year, month)[1]
+
+
+def _add_months(d: date, months: int) -> date:
+    total_month_index = d.month - 1 + months
+    year = d.year + total_month_index // 12
+    month = total_month_index % 12 + 1
+    day = min(d.day, _last_day_of_month(year, month))
+    return date(year, month, day)
+
+
+def _normalize_semimonthly_start(start: date) -> date:
+    """Snaps an arbitrary date to the actual boundary of the 10th/25th pay
+    period it falls in: days 1-9 belong to the cycle that started the 25th of
+    the *previous* month, 10-24 to the one starting the 10th, 25-31 to the one
+    starting the 25th."""
+    if start.day <= 9:
+        prev_month = _add_months(date(start.year, start.month, 1), -1)
+        return date(prev_month.year, prev_month.month, 25)
+    if start.day <= 24:
+        return date(start.year, start.month, 10)
+    return date(start.year, start.month, 25)
+
+
+def _cycle_bounds(cycle_type: CycleType, start: date) -> tuple[date, date]:
+    """Given a cycle's (already-normalized) start date, returns
+    (this cycle's end date, next cycle's start date)."""
+    if cycle_type == CycleType.WEEKLY:
+        return start + timedelta(days=6), start + timedelta(days=7)
+    if cycle_type == CycleType.BIWEEKLY:
+        return start + timedelta(days=13), start + timedelta(days=14)
+    if cycle_type == CycleType.MONTHLY:
+        next_start = _add_months(start, 1)
+        return next_start - timedelta(days=1), next_start
+    if cycle_type == CycleType.SEMIMONTHLY:
+        if start.day == 10:
+            end = date(start.year, start.month, 24)
+            next_start = date(start.year, start.month, 25)
+        else:  # start.day == 25, guaranteed by normalization/stepping
+            next_month = _add_months(date(start.year, start.month, 1), 1)
+            end = date(next_month.year, next_month.month, 9)
+            next_start = date(next_month.year, next_month.month, 10)
+        return end, next_start
+    raise ValueError(f"Unsupported cycle type: {cycle_type}")  # pragma: no cover
+
+
+def get_forecast(
+    bills: list[ForecastBill],
+    cycle_type: CycleType,
+    start_date: date,
+    end_date: date,
+    starting_balance_cents: int,
+    income_per_cycle_cents: int,
+) -> ForecastResult:
+    if end_date < start_date:
+        raise ValueError("end_date must be on or after start_date")
+
+    schedulable: list[ForecastBill] = []
+    unscheduled: list[UnscheduledBill] = []
+    for bill in bills:
+        reason = validate_recurrence_config(bill)
+        if reason:
+            unscheduled.append(UnscheduledBill(bill_id=bill.id, name=bill.name, reason=reason))
+        else:
+            schedulable.append(bill)
+
+    current_start = (
+        _normalize_semimonthly_start(start_date)
+        if cycle_type == CycleType.SEMIMONTHLY
+        else start_date
+    )
+
+    running_balance = starting_balance_cents
+    cycles: list[ForecastCycle] = []
+
+    while current_start <= end_date:
+        current_end, next_start = _cycle_bounds(cycle_type, current_start)
+        cycle = build_cycle(schedulable, current_start, current_end)
+        # Bills are stored (and displayed) as positive amounts throughout Tally
+        # (see Bill.amount_cents) - unlike the reference engine, which stores
+        # bill amounts pre-negated, so cycle sums subtract here instead of add.
+        running_balance += income_per_cycle_cents - cycle.sum_cents
+        cycles.append(
+            ForecastCycle(
+                start_date=current_start,
+                end_date=current_end,
+                bills=cycle.bills,
+                cycle_sum_cents=cycle.sum_cents,
+                running_balance_cents=running_balance,
+            )
+        )
+        current_start = next_start
+
+    return ForecastResult(
+        cycles=cycles,
+        starting_balance_cents=starting_balance_cents,
+        ending_balance_cents=running_balance,
+        unscheduled_bills=unscheduled,
+    )

--- a/backend/src/forecast/engine.py
+++ b/backend/src/forecast/engine.py
@@ -45,22 +45,21 @@ def _add_months(d: date, months: int) -> date:
     return date(year, month, day)
 
 
-def _normalize_semimonthly_start(start: date) -> date:
-    """Snaps an arbitrary date to the actual boundary of the 10th/25th pay
-    period it falls in: days 1-9 belong to the cycle that started the 25th of
-    the *previous* month, 10-24 to the one starting the 10th, 25-31 to the one
-    starting the 25th."""
-    if start.day <= 9:
-        prev_month = _add_months(date(start.year, start.month, 1), -1)
-        return date(prev_month.year, prev_month.month, 25)
-    if start.day <= 24:
-        return date(start.year, start.month, 10)
-    return date(start.year, start.month, 25)
-
-
 def _cycle_bounds(cycle_type: CycleType, start: date) -> tuple[date, date]:
-    """Given a cycle's (already-normalized) start date, returns
-    (this cycle's end date, next cycle's start date)."""
+    """Given a cycle's start date, returns (this cycle's end date, next
+    cycle's start date).
+
+    For SEMIMONTHLY this deliberately does NOT snap `start` backward onto the
+    nearest 10th/25th boundary first - only the END of whatever half-month
+    period `start` currently falls in, and the START of the next one. Doing
+    otherwise would silently include bills from before the caller's actual
+    start_date in the first cycle, corrupting the meaning of
+    starting_balance_cents (it's meant to be the balance as of start_date,
+    not as of some earlier snapped date). The first cycle can end up shorter
+    than a full half-month as a result (e.g. start_date the 21st produces a
+    21st-24th first cycle) - every cycle after that is a full period, since
+    `next_start` here is always exactly the 10th or 25th.
+    """
     if cycle_type == CycleType.WEEKLY:
         return start + timedelta(days=6), start + timedelta(days=7)
     if cycle_type == CycleType.BIWEEKLY:
@@ -69,10 +68,13 @@ def _cycle_bounds(cycle_type: CycleType, start: date) -> tuple[date, date]:
         next_start = _add_months(start, 1)
         return next_start - timedelta(days=1), next_start
     if cycle_type == CycleType.SEMIMONTHLY:
-        if start.day == 10:
+        if start.day <= 9:
+            end = date(start.year, start.month, 9)
+            next_start = date(start.year, start.month, 10)
+        elif start.day <= 24:
             end = date(start.year, start.month, 24)
             next_start = date(start.year, start.month, 25)
-        else:  # start.day == 25, guaranteed by normalization/stepping
+        else:  # start.day >= 25
             next_month = _add_months(date(start.year, start.month, 1), 1)
             end = date(next_month.year, next_month.month, 9)
             next_start = date(next_month.year, next_month.month, 10)
@@ -100,12 +102,7 @@ def get_forecast(
         else:
             schedulable.append(bill)
 
-    current_start = (
-        _normalize_semimonthly_start(start_date)
-        if cycle_type == CycleType.SEMIMONTHLY
-        else start_date
-    )
-
+    current_start = start_date
     running_balance = starting_balance_cents
     cycles: list[ForecastCycle] = []
 

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -2,13 +2,14 @@ from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from mangum import Mangum
 
-from src.api import accounts, bills
+from src.api import accounts, bills, forecast
 from src.core.auth import get_current_user
 
 app = FastAPI()
 
 app.include_router(accounts.router)
 app.include_router(bills.router)
+app.include_router(forecast.router)
 
 # Only needed for local dev: the frontend (:5173) and backend (:8000) run on
 # different origins there. In prod they share an origin via CloudFront's

--- a/backend/src/models/__init__.py
+++ b/backend/src/models/__init__.py
@@ -1,4 +1,4 @@
-from src.models.bank_account import BankAccount
+from src.models.bank_account import BankAccount, CycleType
 from src.models.bill import Bill, RecurrenceType
 from src.models.transaction import Transaction
 from src.models.user import User
@@ -7,6 +7,7 @@ from src.models.windfall import Windfall
 __all__ = [
     "BankAccount",
     "Bill",
+    "CycleType",
     "RecurrenceType",
     "Transaction",
     "User",

--- a/backend/src/models/bank_account.py
+++ b/backend/src/models/bank_account.py
@@ -1,9 +1,17 @@
-from datetime import datetime
+import enum
+from datetime import date, datetime
 
-from sqlalchemy import DateTime, ForeignKey, String, func
+from sqlalchemy import BigInteger, Date, DateTime, Enum, ForeignKey, String, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.core.database import Base
+
+
+class CycleType(str, enum.Enum):
+    WEEKLY = "weekly"
+    BIWEEKLY = "biweekly"
+    MONTHLY = "monthly"
+    SEMIMONTHLY = "semimonthly"
 
 
 class BankAccount(Base):
@@ -18,6 +26,23 @@ class BankAccount(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )
+
+    # Last-used forecast settings, persisted so revisiting the forecast page
+    # doesn't require re-entering the starting balance/date range every time -
+    # pay cycles are ~2 weeks apart and users check back on the same cycle
+    # repeatedly. Set as a side effect of POST .../forecast, not editable
+    # directly (no equivalent field on BankAccountUpdate).
+    forecast_starting_balance_cents: Mapped[int | None] = mapped_column(BigInteger)
+    forecast_income_per_cycle_cents: Mapped[int | None] = mapped_column(BigInteger)
+    forecast_cycle_type: Mapped[CycleType | None] = mapped_column(
+        Enum(
+            CycleType,
+            name="cycle_type",
+            values_callable=lambda enum_cls: [member.value for member in enum_cls],
+        )
+    )
+    forecast_start_date: Mapped[date | None] = mapped_column(Date)
+    forecast_end_date: Mapped[date | None] = mapped_column(Date)
 
     user: Mapped["User"] = relationship(back_populates="bank_accounts")
     bills: Mapped[list["Bill"]] = relationship(

--- a/backend/src/schemas/bank_account.py
+++ b/backend/src/schemas/bank_account.py
@@ -1,6 +1,8 @@
-from datetime import datetime
+from datetime import date, datetime
 
 from pydantic import BaseModel, ConfigDict
+
+from src.models.bank_account import CycleType
 
 
 class BankAccountCreate(BaseModel):
@@ -20,3 +22,10 @@ class BankAccountRead(BaseModel):
     name: str
     institution: str | None
     created_at: datetime
+    # Last-used forecast settings (null until a forecast has been run for this
+    # account at least once) - see schemas/forecast.py's ForecastRequest.
+    forecast_starting_balance_cents: int | None
+    forecast_income_per_cycle_cents: int | None
+    forecast_cycle_type: CycleType | None
+    forecast_start_date: date | None
+    forecast_end_date: date | None

--- a/backend/src/schemas/forecast.py
+++ b/backend/src/schemas/forecast.py
@@ -1,0 +1,49 @@
+from datetime import date
+
+from pydantic import BaseModel, field_validator
+
+from src.models.bank_account import CycleType
+
+
+class ForecastRequest(BaseModel):
+    start_date: date
+    end_date: date
+    starting_balance_cents: int
+    income_per_cycle_cents: int
+    cycle_type: CycleType
+
+    @field_validator("end_date")
+    @classmethod
+    def _end_on_or_after_start(cls, end_date: date, info) -> date:
+        start_date = info.data.get("start_date")
+        if start_date and end_date < start_date:
+            raise ValueError("end_date must be on or after start_date")
+        return end_date
+
+
+class ForecastBillLine(BaseModel):
+    bill_id: int
+    name: str
+    amount_cents: int
+    due_date: date
+
+
+class ForecastCycle(BaseModel):
+    start_date: date
+    end_date: date
+    bills: list[ForecastBillLine]
+    cycle_sum_cents: int
+    running_balance_cents: int
+
+
+class UnscheduledBill(BaseModel):
+    bill_id: int
+    name: str
+    reason: str
+
+
+class ForecastResponse(BaseModel):
+    cycles: list[ForecastCycle]
+    starting_balance_cents: int
+    ending_balance_cents: int
+    unscheduled_bills: list[UnscheduledBill]

--- a/backend/tests/test_forecast_api.py
+++ b/backend/tests/test_forecast_api.py
@@ -1,0 +1,130 @@
+import pytest
+from httpx import AsyncClient
+
+from src.core.auth import get_current_user
+from src.main import app
+from tests.conftest import auth_as
+
+
+def _login_as(sub: str) -> None:
+    app.dependency_overrides[get_current_user] = auth_as(sub)
+
+
+@pytest.fixture(autouse=True)
+def _default_user():
+    _login_as("auth0|owner")
+    yield
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+async def _create_account(client: AsyncClient) -> dict:
+    res = await client.post("/api/v1/accounts", json={"name": "Checking"})
+    return res.json()
+
+
+def _bill_payload(**overrides) -> dict:
+    payload = {
+        "name": "Rent",
+        "amount_cents": 150000,
+        "recurrence_type": "monthly",
+        "start_date": "2024-01-15",
+        "enabled": True,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _forecast_payload(**overrides) -> dict:
+    payload = {
+        "start_date": "2024-01-01",
+        "end_date": "2024-02-29",
+        "starting_balance_cents": 100000,
+        "income_per_cycle_cents": 200000,
+        "cycle_type": "monthly",
+    }
+    payload.update(overrides)
+    return payload
+
+
+async def test_forecast_computes_cycles_and_running_balance(client: AsyncClient):
+    account = await _create_account(client)
+    await client.post(f"/api/v1/accounts/{account['id']}/bills", json=_bill_payload())
+
+    res = await client.post(
+        f"/api/v1/accounts/{account['id']}/forecast", json=_forecast_payload()
+    )
+    assert res.status_code == 200
+    body = res.json()
+    assert len(body["cycles"]) == 2
+    assert body["cycles"][0]["bills"][0]["name"] == "Rent"
+    # 100000 + 200000*2 - 150000*2 = 200000
+    assert body["ending_balance_cents"] == 200000
+    assert body["unscheduled_bills"] == []
+
+
+async def test_forecast_excludes_disabled_bills(client: AsyncClient):
+    account = await _create_account(client)
+    await client.post(
+        f"/api/v1/accounts/{account['id']}/bills", json=_bill_payload(enabled=False)
+    )
+
+    res = await client.post(
+        f"/api/v1/accounts/{account['id']}/forecast", json=_forecast_payload()
+    )
+    assert res.status_code == 200
+    body = res.json()
+    assert all(cycle["bills"] == [] for cycle in body["cycles"])
+    assert body["ending_balance_cents"] == 100000 + 200000 * 2
+
+
+async def test_forecast_reports_bills_missing_recurrence_config(client: AsyncClient):
+    account = await _create_account(client)
+    await client.post(
+        f"/api/v1/accounts/{account['id']}/bills",
+        json=_bill_payload(recurrence_type="custom_days"),
+    )
+
+    res = await client.post(
+        f"/api/v1/accounts/{account['id']}/forecast", json=_forecast_payload()
+    )
+    assert res.status_code == 200
+    body = res.json()
+    assert len(body["unscheduled_bills"]) == 1
+    assert "interval_days" in body["unscheduled_bills"][0]["reason"]
+
+
+async def test_forecast_persists_settings_onto_account(client: AsyncClient):
+    account = await _create_account(client)
+
+    payload = _forecast_payload()
+    res = await client.post(f"/api/v1/accounts/{account['id']}/forecast", json=payload)
+    assert res.status_code == 200
+
+    res = await client.get(f"/api/v1/accounts/{account['id']}")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["forecast_starting_balance_cents"] == payload["starting_balance_cents"]
+    assert body["forecast_income_per_cycle_cents"] == payload["income_per_cycle_cents"]
+    assert body["forecast_cycle_type"] == payload["cycle_type"]
+    assert body["forecast_start_date"] == payload["start_date"]
+    assert body["forecast_end_date"] == payload["end_date"]
+
+
+async def test_forecast_scoped_to_account_owner(client: AsyncClient):
+    account = await _create_account(client)
+
+    _login_as("auth0|someone-else")
+    res = await client.post(
+        f"/api/v1/accounts/{account['id']}/forecast", json=_forecast_payload()
+    )
+    assert res.status_code == 404
+
+
+async def test_forecast_end_date_before_start_date_is_rejected(client: AsyncClient):
+    account = await _create_account(client)
+
+    res = await client.post(
+        f"/api/v1/accounts/{account['id']}/forecast",
+        json=_forecast_payload(start_date="2024-02-01", end_date="2024-01-01"),
+    )
+    assert res.status_code == 422

--- a/backend/tests/test_forecast_engine.py
+++ b/backend/tests/test_forecast_engine.py
@@ -14,7 +14,13 @@ reference's day-bucket boundary for snapping an arbitrary start date onto the
 10th/25th anchor is itself buggy (day 21 snaps to the 25th, skipping the
 still-in-progress 10th-24th period entirely) and is exactly the
 `start`/`next` object-aliasing code this port intentionally rewrites rather
-than reproduces - see _normalize_semimonthly_start in engine.py. The
+than reproduces. This port goes further than just fixing the bucket
+boundary, though: it doesn't snap the *first* cycle's start backward onto a
+10th/25th anchor at all (see _cycle_bounds in engine.py) - doing so would
+silently include bills from before the caller's actual start_date in the
+first cycle, corrupting the meaning of starting_balance_cents (a real bug
+caught in PR review). The first semimonthly cycle can end up shorter than a
+full half-month as a result; every cycle after that is a full period. The
 semimonthly cases below pin this engine's own (verified self-consistent)
 output instead.
 """
@@ -125,7 +131,21 @@ class TestGetForecastSemimonthly:
         ]
         result = get_forecast(bills, CycleType.SEMIMONTHLY, date(1985, 10, 21), date(1985, 11, 28), 2498, 15999)
         assert len(result.cycles) == 4
-        assert result.ending_balance_cents == -497476
+        assert result.ending_balance_cents == -215491
+
+    def test_first_cycle_honors_exact_start_date_not_the_10th_25th_anchor(self):
+        # A mid-period start_date (the 21st) must not be snapped backward to
+        # the 10th - that would silently pull bills due the 10th-20th into
+        # the first cycle even though starting_balance_cents is supposed to
+        # represent the balance as of the 21st, not the 10th.
+        bill = make_bill(1, "already happened", 5000, date(2024, 1, 15))
+        result = get_forecast(
+            [bill], CycleType.SEMIMONTHLY, date(2024, 1, 21), date(2024, 1, 21), 0, 0
+        )
+        assert result.cycles[0].start_date == date(2024, 1, 21)
+        assert result.cycles[0].end_date == date(2024, 1, 24)
+        assert result.cycles[0].bills == []
+        assert result.ending_balance_cents == 0
 
 
 class TestGetForecastWeekly:

--- a/backend/tests/test_forecast_engine.py
+++ b/backend/tests/test_forecast_engine.py
@@ -207,8 +207,6 @@ class TestRecurrenceConfigValidation:
         assert validate_recurrence_config(bill) is not None
         with pytest.raises(MissingRecurrenceConfig):
             occurrences_in_range(bill, date(2024, 3, 1), date(2024, 3, 31))
-        with pytest.raises(MissingRecurrenceConfig):
-            occurrences_in_range(bill, date(2024, 3, 1), date(2024, 3, 31))
 
     def test_custom_days_with_config(self):
         bill = make_bill(

--- a/backend/tests/test_forecast_engine.py
+++ b/backend/tests/test_forecast_engine.py
@@ -193,6 +193,20 @@ class TestRecurrenceConfigValidation:
     def test_semimonthly_missing_config_raises(self):
         bill = make_bill(1, "rent", 50000, date(2024, 1, 1), recurrence_type=RecurrenceType.SEMIMONTHLY)
         assert validate_recurrence_config(bill) is not None
+
+    @pytest.mark.parametrize("days", [[0, 25], [10, 32], [-5, 10]])
+    def test_semimonthly_out_of_range_days_raises_instead_of_crashing(self, days):
+        # date(year, month, day) raises ValueError for day outside 1-31 - out
+        # of range recurrence_config.days must be treated as missing config
+        # (skip + reason), not reach date() construction and 500 the request.
+        bill = make_bill(
+            1, "rent", 50000, date(2024, 1, 1),
+            recurrence_type=RecurrenceType.SEMIMONTHLY,
+            recurrence_config={"days": days},
+        )
+        assert validate_recurrence_config(bill) is not None
+        with pytest.raises(MissingRecurrenceConfig):
+            occurrences_in_range(bill, date(2024, 3, 1), date(2024, 3, 31))
         with pytest.raises(MissingRecurrenceConfig):
             occurrences_in_range(bill, date(2024, 3, 1), date(2024, 3, 31))
 

--- a/backend/tests/test_forecast_engine.py
+++ b/backend/tests/test_forecast_engine.py
@@ -1,0 +1,238 @@
+"""Pure unit tests for src/forecast - no DB, no HTTP.
+
+The bi-weekly and monthly golden values below are ported directly from the
+reference TypeScript engine's test suites (kenhowardpdx/bank,
+packages/forecast/src/__tests__/{cycle,forecast}.test.ts), converted from
+dollar strings to cents and adapted to Tally's positive-amount convention
+(Bill.amount_cents is stored positive; the reference stores bill amounts
+pre-negated). All bills in the reference fixtures omit `type`, which the
+reference's Bill class treats as falsy-not-"annually" - i.e. they behave as
+monthly bills, ported here as RecurrenceType.MONTHLY.
+
+The semimonthly (10th/25th) golden values are NOT ported as-is: the
+reference's day-bucket boundary for snapping an arbitrary start date onto the
+10th/25th anchor is itself buggy (day 21 snaps to the 25th, skipping the
+still-in-progress 10th-24th period entirely) and is exactly the
+`start`/`next` object-aliasing code this port intentionally rewrites rather
+than reproduces - see _normalize_semimonthly_start in engine.py. The
+semimonthly cases below pin this engine's own (verified self-consistent)
+output instead.
+"""
+
+from datetime import date
+
+import pytest
+
+from src.forecast import ForecastBill, MissingRecurrenceConfig, build_cycle, get_forecast
+from src.forecast.bill import occurrences_in_range, validate_recurrence_config
+from src.models.bank_account import CycleType
+from src.models.bill import RecurrenceType
+
+
+def make_bill(
+    id: int,
+    name: str,
+    amount_cents: int,
+    start_date: date,
+    end_date: date | None = None,
+    recurrence_type: RecurrenceType = RecurrenceType.MONTHLY,
+    recurrence_config: dict | None = None,
+) -> ForecastBill:
+    return ForecastBill(
+        id=id,
+        name=name,
+        amount_cents=amount_cents,
+        recurrence_type=recurrence_type,
+        recurrence_config=recurrence_config or {},
+        start_date=start_date,
+        end_date=end_date,
+    )
+
+
+class TestGetForecastBiWeeklyGoldenValues:
+    def test_no_bills_single_cycle(self):
+        result = get_forecast([], CycleType.BIWEEKLY, date(1985, 10, 21), date(1985, 10, 28), 2498, 15999)
+        assert len(result.cycles) == 1
+        assert result.ending_balance_cents == 18497
+
+    def test_no_bills_multiple_cycles(self):
+        result = get_forecast([], CycleType.BIWEEKLY, date(1985, 10, 21), date(1985, 11, 28), 2498, 15999)
+        assert len(result.cycles) == 3
+        assert result.ending_balance_cents == 50495
+
+    def test_two_bills(self):
+        bills = [
+            make_bill(1, "foo", 10000, date(1985, 10, 11)),
+            make_bill(2, "bar", 1985, date(1985, 1, 18)),
+        ]
+        result = get_forecast(bills, CycleType.BIWEEKLY, date(1985, 10, 21), date(1985, 11, 28), 2498, 15999)
+        assert len(result.cycles) == 3
+        assert result.ending_balance_cents == 38510
+
+    def test_two_bills_one_large_goes_negative(self):
+        bills = [
+            make_bill(1, "foo", 10000, date(1985, 10, 11)),
+            make_bill(2, "bar", 271985, date(1985, 1, 18)),
+        ]
+        result = get_forecast(bills, CycleType.BIWEEKLY, date(1985, 10, 21), date(1985, 11, 28), 2498, 15999)
+        assert len(result.cycles) == 3
+        assert result.ending_balance_cents == -231490
+
+
+class TestGetForecastMonthlyGoldenValues:
+    def test_no_bills_single_cycle(self):
+        result = get_forecast([], CycleType.MONTHLY, date(1985, 10, 21), date(1985, 10, 28), 2498, 15999)
+        assert len(result.cycles) == 1
+        assert result.ending_balance_cents == 18497
+
+    def test_no_bills_multiple_cycles(self):
+        result = get_forecast([], CycleType.MONTHLY, date(1985, 10, 21), date(1986, 1, 22), 2498, 15999)
+        assert len(result.cycles) == 4
+        assert result.ending_balance_cents == 66494
+
+    def test_two_bills(self):
+        bills = [
+            make_bill(1, "foo", 10000, date(1985, 10, 11)),
+            make_bill(2, "bar", 1985, date(1985, 1, 18)),
+        ]
+        result = get_forecast(bills, CycleType.MONTHLY, date(1985, 10, 21), date(1986, 1, 20), 2498, 15999)
+        assert len(result.cycles) == 3
+        assert result.ending_balance_cents == 14540
+
+    def test_two_bills_one_large_goes_negative(self):
+        bills = [
+            make_bill(1, "foo", 10000, date(1985, 10, 11)),
+            make_bill(2, "bar", 271985, date(1985, 1, 18)),
+        ]
+        result = get_forecast(bills, CycleType.MONTHLY, date(1985, 10, 21), date(1985, 11, 28), 2498, 15999)
+        assert len(result.cycles) == 2
+        assert result.ending_balance_cents == -529474
+
+
+class TestGetForecastSemimonthly:
+    """See module docstring - these pin this engine's own corrected output,
+    not the reference's (buggy) day-bucket snapping."""
+
+    def test_no_bills(self):
+        result = get_forecast([], CycleType.SEMIMONTHLY, date(1985, 10, 21), date(1985, 12, 28), 2498, 15999)
+        assert len(result.cycles) == 6
+        assert result.ending_balance_cents == 98492
+
+    def test_two_bills_one_large_goes_negative(self):
+        bills = [
+            make_bill(1, "foo", 10000, date(1985, 10, 11)),
+            make_bill(2, "bar", 271985, date(1985, 1, 18)),
+        ]
+        result = get_forecast(bills, CycleType.SEMIMONTHLY, date(1985, 10, 21), date(1985, 11, 28), 2498, 15999)
+        assert len(result.cycles) == 4
+        assert result.ending_balance_cents == -497476
+
+
+class TestGetForecastWeekly:
+    """No reference fixture exists for this - the reference's engine leaves
+    weekly unimplemented ("NOT IMPLEMENTED"). Hand-verified."""
+
+    def test_no_bills(self):
+        result = get_forecast([], CycleType.WEEKLY, date(2024, 1, 1), date(2024, 1, 21), 0, 1000)
+        # 3 flush 7-day windows: 1/1-1/7, 1/8-1/14, 1/15-1/21
+        assert len(result.cycles) == 3
+        assert result.ending_balance_cents == 3000
+
+    def test_weekly_bill_recurs_multiple_times_within_a_monthly_cycle(self):
+        """A weekly-recurring bill inside a longer (monthly) cycle window can
+        genuinely recur more than once - the reference's single-occurrence-
+        per-cycle model can't represent this; this port generalizes it."""
+        bill = make_bill(1, "coffee", 500, date(2024, 1, 3), recurrence_type=RecurrenceType.WEEKLY)
+        result = get_forecast([bill], CycleType.MONTHLY, date(2024, 1, 1), date(2024, 1, 31), 0, 0)
+        assert len(result.cycles) == 1
+        # Jan 3, 10, 17, 24, 31 - five occurrences within the one monthly cycle.
+        assert len(result.cycles[0].bills) == 5
+        assert result.ending_balance_cents == -2500
+
+
+class TestCycleGoldenValue:
+    """Ports cycle.test.ts's "multiple cycles" fixture - one terminated bill
+    plus two open-ended ones, evaluated a month apart."""
+
+    def test_bill_with_end_date_drops_out_of_later_cycle(self):
+        bills = [
+            make_bill(1, "bill one", 1525, date(1985, 10, 22), end_date=date(1985, 10, 22)),
+            make_bill(2, "bill two", 1525, date(1985, 10, 22)),
+            make_bill(3, "bill three", 1525, date(1985, 10, 23)),
+        ]
+        cycle_one = build_cycle(bills, date(1985, 10, 21), date(1985, 10, 28))
+        cycle_two = build_cycle(bills, date(1985, 11, 21), date(1985, 11, 28))
+
+        assert len(cycle_one.bills) != len(cycle_two.bills)
+        assert cycle_one.sum_cents + cycle_two.sum_cents == 7625
+
+
+class TestDueDateMonthEndClamping:
+    def test_bill_anchored_on_31st_clamps_in_february(self):
+        bill = make_bill(1, "rent", 100000, date(2023, 1, 31))
+        occurrences = occurrences_in_range(bill, date(2024, 2, 1), date(2024, 2, 29))
+        assert occurrences == [date(2024, 2, 29)]
+
+    def test_bill_anchored_on_31st_clamps_in_non_leap_february(self):
+        bill = make_bill(1, "rent", 100000, date(2023, 1, 31))
+        occurrences = occurrences_in_range(bill, date(2023, 2, 1), date(2023, 2, 28))
+        assert occurrences == [date(2023, 2, 28)]
+
+
+class TestRecurrenceConfigValidation:
+    def test_semimonthly_with_config(self):
+        bill = make_bill(
+            1, "rent", 50000, date(2024, 1, 1),
+            recurrence_type=RecurrenceType.SEMIMONTHLY,
+            recurrence_config={"days": [10, 25]},
+        )
+        assert validate_recurrence_config(bill) is None
+        occurrences = occurrences_in_range(bill, date(2024, 3, 1), date(2024, 3, 31))
+        assert occurrences == [date(2024, 3, 10), date(2024, 3, 25)]
+
+    def test_semimonthly_missing_config_raises(self):
+        bill = make_bill(1, "rent", 50000, date(2024, 1, 1), recurrence_type=RecurrenceType.SEMIMONTHLY)
+        assert validate_recurrence_config(bill) is not None
+        with pytest.raises(MissingRecurrenceConfig):
+            occurrences_in_range(bill, date(2024, 3, 1), date(2024, 3, 31))
+
+    def test_custom_days_with_config(self):
+        bill = make_bill(
+            1, "trash", 2000, date(2024, 1, 1),
+            recurrence_type=RecurrenceType.CUSTOM_DAYS,
+            recurrence_config={"interval_days": 45},
+        )
+        occurrences = occurrences_in_range(bill, date(2024, 2, 1), date(2024, 2, 29))
+        assert occurrences == [date(2024, 2, 15)]
+
+    def test_custom_days_missing_config_raises(self):
+        bill = make_bill(1, "trash", 2000, date(2024, 1, 1), recurrence_type=RecurrenceType.CUSTOM_DAYS)
+        with pytest.raises(MissingRecurrenceConfig):
+            occurrences_in_range(bill, date(2024, 2, 1), date(2024, 2, 29))
+
+    def test_get_forecast_skips_unconfigured_bills_instead_of_failing(self):
+        good_bill = make_bill(1, "rent", 50000, date(2024, 1, 1))
+        bad_bill = make_bill(
+            2, "irregular", 2000, date(2024, 1, 1), recurrence_type=RecurrenceType.CUSTOM_DAYS
+        )
+        result = get_forecast(
+            [good_bill, bad_bill], CycleType.MONTHLY, date(2024, 1, 1), date(2024, 1, 31), 0, 0
+        )
+        assert len(result.unscheduled_bills) == 1
+        assert result.unscheduled_bills[0].bill_id == 2
+        # good_bill still gets forecast normally despite bad_bill's problem.
+        assert len(result.cycles[0].bills) == 1
+        assert result.cycles[0].bills[0].bill_id == 1
+
+
+class TestGetForecastValidation:
+    def test_end_date_before_start_date_raises(self):
+        with pytest.raises(ValueError):
+            get_forecast([], CycleType.MONTHLY, date(2024, 2, 1), date(2024, 1, 1), 0, 0)
+
+    def test_single_day_range_still_produces_one_cycle(self):
+        # Deliberate improvement over the reference, which produces zero
+        # cycles when end_date == start_date (an untested degenerate case
+        # there) - a forecast for a single day should still show that day.
+        result = get_forecast([], CycleType.MONTHLY, date(2024, 1, 1), date(2024, 1, 1), 0, 0)
+        assert len(result.cycles) == 1

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -200,18 +200,41 @@ per-PR preview branch) make manual Neon console clicks a recurring chore.
 
 ## Phase 2 — Forecast Engine
 
-**Status**: not started
+**Status**: code complete
 
-- [ ] 2.1 Port `Amount`/`Bill`/`Cycle`/`getForecast` to Python with `Decimal` math;
-      port the existing test cases (`packages/forecast/src/__tests__/*`) to pytest as
-      the correctness baseline
-- [ ] 2.2 Extend the engine for the new recurrence types beyond monthly/annual (weekly,
-      semimonthly, custom-interval-days)
-- [ ] 2.3 Backend forecast endpoint (account, date range, starting balance, income per
-      cycle → cycle-by-cycle breakdown)
-- [ ] 2.4 Frontend forecast view (Svelte equivalent of `clientv0`'s `Forecast.tsx`:
-      cycle rows with running total, expandable to show which bills/transactions hit
-      that cycle)
+- [x] 2.1 Port `Bill`/`Cycle`/`getForecast` to Python (`backend/src/forecast/`); no
+      `Amount`/`Decimal` needed - `Bill.amount_cents` is already exact integer cents, so
+      the whole engine is plain int arithmetic. Ported the bi-weekly/monthly golden-value
+      test cases from `packages/forecast/src/__tests__/{cycle,forecast}.test.ts` directly
+      (exact cents-converted parity); the semimonthly ("10th & 25th") cases were **not**
+      ported as-is - the reference's day-bucket boundary for snapping onto the 10th/25th
+      anchor is itself part of the `start`/`next` aliasing bug this port fixes rather than
+      reproduces (day 21 snapped to the 25th in the reference, skipping the still-active
+      10th-24th period), so those pin this engine's own corrected, self-verified output
+      instead. See `backend/tests/test_forecast_engine.py`'s module docstring.
+- [x] 2.2 Extended for weekly/semimonthly/custom_days per-bill recurrence (`RecurrenceType`,
+      already modeled in Phase 1), plus a `weekly` *cycle* type the reference left as
+      `throw new Error("NOT IMPLEMENTED")`. Also generalized beyond the reference's
+      single-occurrence-per-cycle model: a weekly-recurring bill inside a monthly forecast
+      cycle can genuinely recur more than once in that window, and now all occurrences
+      count (see `test_weekly_bill_recurs_multiple_times_within_a_monthly_cycle`).
+      Bills needing `recurrence_config` data that doesn't exist yet (semimonthly,
+      custom_days - 1.7 was deferred) are skipped with a reason rather than guessed at or
+      failing the whole request (`ForecastResponse.unscheduled_bills`).
+- [x] 2.3 `POST /api/v1/accounts/{id}/forecast` (`backend/src/api/forecast.py`) - only
+      `enabled` bills, scoped via the existing `get_owned_bank_account` pattern. Also
+      persists the request's five params onto the account (`BankAccount.forecast_*`
+      columns, new migration) as a side effect, so `GET .../accounts/{id}` returns the
+      last-used settings - added after a plan review caught that the reference's
+      client persisted these to `localforage` for exactly this reason (pay cycles are
+      ~2 weeks apart; don't make the user re-enter the starting balance every visit).
+- [x] 2.4 `frontend/src/routes/(app)/accounts/[id]/forecast/+page.svelte` - a separate
+      route rather than the reference's same-page tab (fits SvelteKit's routing model
+      better, keeps the bills page from growing further); form prefilled from the
+      account's saved settings, explicit "Calculate" submit (a real API round-trip now,
+      not the reference's free client-side recompute-on-keystroke); cycle rows expand
+      in place to show bill line items, with the reference's red/gray
+      negative/low-balance row coloring ported to Tailwind classes.
 
 ## Phase 3 — Transactions & Windfalls
 
@@ -315,3 +338,13 @@ session (or a fresh Claude Code instance) orient in under a minute.
   popover calendar, no new dependency) components; "Recurrence" renamed to "Frequency" with
   human-readable value labels everywhere. Left 1.7 alone (recurrence-config UI) per its own
   "not yet designed" flag. Next: scope 1.7, or start Phase 2.
+- 2026-07-12: Phase 2 (forecast engine) shipped — ported the reference `kenhowardpdx/bank`
+  engine to `backend/src/forecast/`, extended for Tally's full recurrence model, and added
+  the `POST .../forecast` endpoint + `/accounts/[id]/forecast` Svelte page. Persisted
+  forecast settings onto `BankAccount` (new columns/migration) after catching mid-plan that
+  the reference persists these client-side for a real reason (~2-week pay cycles, don't
+  re-enter the starting balance every visit) — worth remembering for future phases: check
+  whether "ephemeral request params" in a reference implementation are actually ephemeral,
+  or just persisted somewhere this port doesn't have yet. 1.7 (recurrence-config UI) is
+  still open and still blocks semimonthly/custom_days bills from being real (they show up
+  as "unscheduled" in any forecast). Next: 1.7, or Phase 3 (transactions & windfalls).

--- a/frontend/src/lib/api/forecast.ts
+++ b/frontend/src/lib/api/forecast.ts
@@ -1,0 +1,12 @@
+import { apiJson } from '$lib/api';
+import type { ForecastRequest, ForecastResponse } from '$lib/api/types';
+
+export function computeForecast(
+	accountId: number,
+	input: ForecastRequest
+): Promise<ForecastResponse> {
+	return apiJson(`/api/v1/accounts/${accountId}/forecast`, {
+		method: 'POST',
+		body: JSON.stringify(input)
+	});
+}

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -6,11 +6,21 @@ export type RecurrenceType =
 	| 'annually'
 	| 'custom_days';
 
+// Pay-period cadence for forecasting - distinct from RecurrenceType (how
+// often a given bill recurs). Not persisted independently; lives only as
+// the account's last-used forecast setting (see BankAccount.forecast_*).
+export type CycleType = 'weekly' | 'biweekly' | 'monthly' | 'semimonthly';
+
 export interface BankAccount {
 	id: number;
 	name: string;
 	institution: string | null;
 	created_at: string;
+	forecast_starting_balance_cents: number | null;
+	forecast_income_per_cycle_cents: number | null;
+	forecast_cycle_type: CycleType | null;
+	forecast_start_date: string | null;
+	forecast_end_date: string | null;
 }
 
 export interface BankAccountInput {
@@ -40,4 +50,40 @@ export interface BillInput {
 	start_date: string;
 	end_date?: string | null;
 	enabled?: boolean;
+}
+
+export interface ForecastRequest {
+	start_date: string;
+	end_date: string;
+	starting_balance_cents: number;
+	income_per_cycle_cents: number;
+	cycle_type: CycleType;
+}
+
+export interface ForecastBillLine {
+	bill_id: number;
+	name: string;
+	amount_cents: number;
+	due_date: string;
+}
+
+export interface ForecastCycle {
+	start_date: string;
+	end_date: string;
+	bills: ForecastBillLine[];
+	cycle_sum_cents: number;
+	running_balance_cents: number;
+}
+
+export interface UnscheduledBill {
+	bill_id: number;
+	name: string;
+	reason: string;
+}
+
+export interface ForecastResponse {
+	cycles: ForecastCycle[];
+	starting_balance_cents: number;
+	ending_balance_cents: number;
+	unscheduled_bills: UnscheduledBill[];
 }

--- a/frontend/src/lib/components/Input.svelte
+++ b/frontend/src/lib/components/Input.svelte
@@ -5,7 +5,8 @@
 		type = 'text',
 		placeholder,
 		required = false,
-		id
+		id,
+		step
 	}: {
 		label?: string;
 		value?: string;
@@ -13,6 +14,7 @@
 		placeholder?: string;
 		required?: boolean;
 		id?: string;
+		step?: string;
 	} = $props();
 
 	const inputId = id ?? label?.toLowerCase().replace(/\s+/g, '-');
@@ -27,6 +29,7 @@
 		{type}
 		{placeholder}
 		{required}
+		{step}
 		bind:value
 		class="rounded-card border border-slate-300 px-3 py-2 text-sm text-text focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
 	/>

--- a/frontend/src/lib/cycle.ts
+++ b/frontend/src/lib/cycle.ts
@@ -1,0 +1,8 @@
+import type { CycleType } from '$lib/api/types';
+
+export const cycleTypeLabels: Record<CycleType, string> = {
+	weekly: 'Weekly',
+	biweekly: 'Biweekly',
+	monthly: 'Monthly',
+	semimonthly: 'Semimonthly (10th & 25th)'
+};

--- a/frontend/src/routes/(app)/accounts/[id]/+page.svelte
+++ b/frontend/src/routes/(app)/accounts/[id]/+page.svelte
@@ -139,9 +139,12 @@
 </script>
 
 <a class="text-sm text-primary underline" href="/accounts">&larr; Accounts</a>
-<h1 class="mt-2 text-2xl font-semibold text-text">
-	Bills{#if account} ({account.name}{#if account.institution} - {account.institution}{/if}){/if}
-</h1>
+<div class="mt-2 flex items-center justify-between">
+	<h1 class="text-2xl font-semibold text-text">
+		Bills{#if account} ({account.name}{#if account.institution} - {account.institution}{/if}){/if}
+	</h1>
+	<a class="text-sm text-primary underline" href="/accounts/{accountId}/forecast">Forecast &rarr;</a>
+</div>
 
 {#if error}
 	<p class="mt-4 rounded-card bg-red-50 px-4 py-2 text-sm text-red-700">{error}</p>

--- a/frontend/src/routes/(app)/accounts/[id]/forecast/+page.svelte
+++ b/frontend/src/routes/(app)/accounts/[id]/forecast/+page.svelte
@@ -1,0 +1,175 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+	import { getAccount } from '$lib/api/accounts';
+	import { computeForecast } from '$lib/api/forecast';
+	import type { BankAccount, CycleType, ForecastResponse } from '$lib/api/types';
+	import Button from '$lib/components/Button.svelte';
+	import Card from '$lib/components/Card.svelte';
+	import DatePicker from '$lib/components/DatePicker.svelte';
+	import Input from '$lib/components/Input.svelte';
+	import Select from '$lib/components/Select.svelte';
+	import Table from '$lib/components/Table.svelte';
+	import { cycleTypeLabels } from '$lib/cycle';
+	import { onMount } from 'svelte';
+
+	const accountId = $derived(Number($page.params.id));
+
+	const cycleTypeOptions: CycleType[] = ['weekly', 'biweekly', 'monthly', 'semimonthly'];
+
+	let account = $state<BankAccount | null>(null);
+	let loading = $state(true);
+	let calculating = $state(false);
+	let error = $state<string | null>(null);
+	let forecast = $state<ForecastResponse | null>(null);
+	let expanded = $state<Record<string, boolean>>({});
+
+	let startingBalance = $state('0');
+	let incomePerCycle = $state('0');
+	let startDate = $state('');
+	let endDate = $state('');
+	let cycleType = $state<CycleType>('biweekly');
+
+	function isoDate(date: Date): string {
+		return date.toISOString().slice(0, 10);
+	}
+
+	onMount(async () => {
+		loading = true;
+		try {
+			account = await getAccount(accountId);
+			const today = new Date();
+			const inNinetyDays = new Date(today);
+			inNinetyDays.setDate(inNinetyDays.getDate() + 90);
+
+			startingBalance =
+				account.forecast_starting_balance_cents != null
+					? (account.forecast_starting_balance_cents / 100).toString()
+					: '0';
+			incomePerCycle =
+				account.forecast_income_per_cycle_cents != null
+					? (account.forecast_income_per_cycle_cents / 100).toString()
+					: '0';
+			cycleType = account.forecast_cycle_type ?? 'biweekly';
+			startDate = account.forecast_start_date ?? isoDate(today);
+			endDate = account.forecast_end_date ?? isoDate(inNinetyDays);
+		} catch (err) {
+			error = err instanceof Error ? err.message : String(err);
+		} finally {
+			loading = false;
+		}
+	});
+
+	async function handleCalculate(event: SubmitEvent) {
+		event.preventDefault();
+		calculating = true;
+		error = null;
+		try {
+			forecast = await computeForecast(accountId, {
+				start_date: startDate,
+				end_date: endDate,
+				starting_balance_cents: Math.round(Number(startingBalance) * 100),
+				income_per_cycle_cents: Math.round(Number(incomePerCycle) * 100),
+				cycle_type: cycleType
+			});
+			expanded = {};
+		} catch (err) {
+			error = err instanceof Error ? err.message : String(err);
+		} finally {
+			calculating = false;
+		}
+	}
+
+	function toggleExpanded(cycleStart: string) {
+		expanded = { ...expanded, [cycleStart]: !expanded[cycleStart] };
+	}
+
+	function handleRowKeydown(event: KeyboardEvent, cycleStart: string) {
+		if (event.key === 'Enter' || event.key === ' ') {
+			event.preventDefault();
+			toggleExpanded(cycleStart);
+		}
+	}
+
+	function formatAmount(cents: number): string {
+		return (cents / 100).toLocaleString(undefined, { style: 'currency', currency: 'USD' });
+	}
+
+	function rowClass(runningBalanceCents: number): string {
+		if (runningBalanceCents < 0) return 'bg-red-600 text-white';
+		if (runningBalanceCents <= 10000) return 'bg-slate-200';
+		return '';
+	}
+</script>
+
+<a class="text-sm text-primary underline" href="/accounts/{accountId}">&larr; Bills</a>
+<h1 class="mt-2 text-2xl font-semibold text-text">
+	Forecast{#if account}
+		({account.name}{#if account.institution} - {account.institution}{/if}){/if}
+</h1>
+
+{#if error}
+	<p class="mt-4 rounded-card bg-red-50 px-4 py-2 text-sm text-red-700">{error}</p>
+{/if}
+
+<Card>
+	<form class="flex flex-wrap items-end gap-4" onsubmit={handleCalculate}>
+		<Input label="Starting balance ($)" type="number" bind:value={startingBalance} required />
+		<Input label="Income per cycle ($)" type="number" bind:value={incomePerCycle} required />
+		<DatePicker label="Start date" bind:value={startDate} />
+		<DatePicker label="End date" bind:value={endDate} />
+		<Select label="Cycle" bind:value={cycleType}>
+			{#each cycleTypeOptions as option (option)}
+				<option value={option}>{cycleTypeLabels[option]}</option>
+			{/each}
+		</Select>
+		<Button type="submit" disabled={calculating || loading}>Calculate</Button>
+	</form>
+</Card>
+
+{#if forecast}
+	{#if forecast.unscheduled_bills.length > 0}
+		<p class="mt-4 rounded-card bg-amber-50 px-4 py-2 text-sm text-amber-800">
+			{forecast.unscheduled_bills.length} bill{forecast.unscheduled_bills.length === 1
+				? ''
+				: 's'} couldn't be included - missing recurrence configuration:
+			{forecast.unscheduled_bills.map((bill) => bill.name).join(', ')}
+		</p>
+	{/if}
+
+	<div class="mt-6">
+		<Table>
+			<thead>
+				<tr class="border-b border-slate-200 text-xs uppercase text-slate-500">
+					<th class="px-4 py-2 font-medium" colspan="2">Pay period</th>
+					<th class="px-4 py-2 text-right font-medium">Balance</th>
+				</tr>
+			</thead>
+			<tbody>
+				{#each forecast.cycles as cycle (cycle.start_date)}
+					{@const clickable = cycle.bills.length > 0}
+					<tr
+						class="border-b border-slate-100 last:border-0 {clickable
+							? 'cursor-pointer'
+							: ''} {rowClass(cycle.running_balance_cents)}"
+						role={clickable ? 'button' : undefined}
+						tabindex={clickable ? 0 : undefined}
+						onclick={() => clickable && toggleExpanded(cycle.start_date)}
+						onkeydown={(event) => clickable && handleRowKeydown(event, cycle.start_date)}
+					>
+						<td class="px-4 py-2" colspan="2">{cycle.start_date} - {cycle.end_date}</td>
+						<td class="px-4 py-2 text-right">{formatAmount(cycle.running_balance_cents)}</td>
+					</tr>
+					{#if expanded[cycle.start_date]}
+						{#each cycle.bills as bill (bill.bill_id + bill.due_date)}
+							<tr class="border-b border-slate-100 text-sm text-slate-600 last:border-0">
+								<td class="px-4 py-2 pl-8">{bill.due_date}</td>
+								<td class="px-4 py-2">{bill.name}</td>
+								<td class="px-4 py-2 text-right">{formatAmount(bill.amount_cents)}</td>
+							</tr>
+						{/each}
+					{/if}
+				{/each}
+			</tbody>
+		</Table>
+	</div>
+{/if}

--- a/frontend/src/routes/(app)/accounts/[id]/forecast/+page.svelte
+++ b/frontend/src/routes/(app)/accounts/[id]/forecast/+page.svelte
@@ -30,7 +30,13 @@
 	let cycleType = $state<CycleType>('biweekly');
 
 	function isoDate(date: Date): string {
-		return date.toISOString().slice(0, 10);
+		// Local date components, not toISOString() (which formats in UTC and
+		// can shift the day relative to the user's local time) - matches
+		// DatePicker's own toISO() so defaults and picked dates agree.
+		const year = date.getFullYear();
+		const month = String(date.getMonth() + 1).padStart(2, '0');
+		const day = String(date.getDate()).padStart(2, '0');
+		return `${year}-${month}-${day}`;
 	}
 
 	onMount(async () => {

--- a/frontend/src/routes/(app)/accounts/[id]/forecast/+page.svelte
+++ b/frontend/src/routes/(app)/accounts/[id]/forecast/+page.svelte
@@ -61,14 +61,24 @@
 
 	async function handleCalculate(event: SubmitEvent) {
 		event.preventDefault();
+		const startingBalanceCents = Math.round(Number(startingBalance) * 100);
+		const incomePerCycleCents = Math.round(Number(incomePerCycle) * 100);
+		if (
+			!startDate ||
+			!endDate ||
+			Number.isNaN(startingBalanceCents) ||
+			Number.isNaN(incomePerCycleCents)
+		) {
+			return;
+		}
 		calculating = true;
 		error = null;
 		try {
 			forecast = await computeForecast(accountId, {
 				start_date: startDate,
 				end_date: endDate,
-				starting_balance_cents: Math.round(Number(startingBalance) * 100),
-				income_per_cycle_cents: Math.round(Number(incomePerCycle) * 100),
+				starting_balance_cents: startingBalanceCents,
+				income_per_cycle_cents: incomePerCycleCents,
 				cycle_type: cycleType
 			});
 			expanded = {};

--- a/frontend/src/routes/(app)/accounts/[id]/forecast/+page.svelte
+++ b/frontend/src/routes/(app)/accounts/[id]/forecast/+page.svelte
@@ -187,7 +187,7 @@
 						{/if}
 					</tr>
 					{#if expanded[cycle.start_date]}
-						{#each cycle.bills as bill (bill.bill_id + bill.due_date)}
+						{#each cycle.bills as bill (`${bill.bill_id}-${bill.due_date}`)}
 							<tr class="border-b border-slate-100 text-sm text-slate-600 last:border-0">
 								<td class="px-4 py-2 pl-8">{bill.due_date}</td>
 								<td class="px-4 py-2">{bill.name}</td>

--- a/frontend/src/routes/(app)/accounts/[id]/forecast/+page.svelte
+++ b/frontend/src/routes/(app)/accounts/[id]/forecast/+page.svelte
@@ -93,13 +93,6 @@
 		expanded = { ...expanded, [cycleStart]: !expanded[cycleStart] };
 	}
 
-	function handleRowKeydown(event: KeyboardEvent, cycleStart: string) {
-		if (event.key === 'Enter' || event.key === ' ') {
-			event.preventDefault();
-			toggleExpanded(cycleStart);
-		}
-	}
-
 	function formatAmount(cents: number): string {
 		return (cents / 100).toLocaleString(undefined, { style: 'currency', currency: 'USD' });
 	}
@@ -123,8 +116,20 @@
 
 <Card>
 	<form class="flex flex-wrap items-end gap-4" onsubmit={handleCalculate}>
-		<Input label="Starting balance ($)" type="number" bind:value={startingBalance} required />
-		<Input label="Income per cycle ($)" type="number" bind:value={incomePerCycle} required />
+		<Input
+			label="Starting balance ($)"
+			type="number"
+			step="0.01"
+			bind:value={startingBalance}
+			required
+		/>
+		<Input
+			label="Income per cycle ($)"
+			type="number"
+			step="0.01"
+			bind:value={incomePerCycle}
+			required
+		/>
 		<DatePicker label="Start date" bind:value={startDate} />
 		<DatePicker label="End date" bind:value={endDate} />
 		<Select label="Cycle" bind:value={cycleType}>
@@ -157,17 +162,23 @@
 			<tbody>
 				{#each forecast.cycles as cycle (cycle.start_date)}
 					{@const clickable = cycle.bills.length > 0}
-					<tr
-						class="border-b border-slate-100 last:border-0 {clickable
-							? 'cursor-pointer'
-							: ''} {rowClass(cycle.running_balance_cents)}"
-						role={clickable ? 'button' : undefined}
-						tabindex={clickable ? 0 : undefined}
-						onclick={() => clickable && toggleExpanded(cycle.start_date)}
-						onkeydown={(event) => clickable && handleRowKeydown(event, cycle.start_date)}
-					>
-						<td class="px-4 py-2" colspan="2">{cycle.start_date} - {cycle.end_date}</td>
-						<td class="px-4 py-2 text-right">{formatAmount(cycle.running_balance_cents)}</td>
+					<tr class="border-b border-slate-100 last:border-0 {rowClass(cycle.running_balance_cents)}">
+						{#if clickable}
+							<td class="p-0" colspan="3">
+								<button
+									type="button"
+									class="flex w-full cursor-pointer items-center justify-between px-4 py-2 text-left"
+									onclick={() => toggleExpanded(cycle.start_date)}
+									aria-expanded={!!expanded[cycle.start_date]}
+								>
+									<span>{cycle.start_date} - {cycle.end_date}</span>
+									<span>{formatAmount(cycle.running_balance_cents)}</span>
+								</button>
+							</td>
+						{:else}
+							<td class="px-4 py-2" colspan="2">{cycle.start_date} - {cycle.end_date}</td>
+							<td class="px-4 py-2 text-right">{formatAmount(cycle.running_balance_cents)}</td>
+						{/if}
 					</tr>
 					{#if expanded[cycle.start_date]}
 						{#each cycle.bills as bill (bill.bill_id + bill.due_date)}


### PR DESCRIPTION
## Summary

Implements Phase 2 of the roadmap (forecast engine) — ports the cycle/due-date engine
from the reference repo (`kenhowardpdx/bank`) into Tally's Python backend, extends it to
cover Tally's full recurrence model, exposes it as an API endpoint, and builds the Svelte
view. Closes out roadmap items 2.1–2.4.

- **Engine port** (`backend/src/forecast/`): no `Amount`/`Decimal` needed —
  `Bill.amount_cents` is already exact integer cents, so this is plain int arithmetic
  throughout, unlike the reference's `parseFloat`-on-currency-strings approach. Ported the
  bi-weekly/monthly golden-value test cases directly (exact parity, verified against the
  original TS fixtures); semimonthly ("10th & 25th") golden values were **not** ported
  as-is — the reference's day-bucket snapping onto the 10th/25th anchor is itself part of
  a `start`/`next` object-aliasing bug this port fixes rather than reproduces, so those
  tests pin this engine's own corrected, self-verified output instead (documented in the
  test file's module docstring).
- **Extended recurrence** (2.2): weekly/semimonthly/custom_days per-bill recurrence, plus
  a `weekly` *cycle* type the reference left unimplemented. Also generalized beyond the
  reference's single-occurrence-per-cycle model — a weekly bill inside a monthly forecast
  cycle can genuinely recur more than once, and now all occurrences count. Bills missing
  `recurrence_config` they need (semimonthly/custom_days — 1.7 is still deferred) are
  skipped with a reason (`unscheduled_bills` in the response) rather than guessed at or
  failing the whole forecast.
- **API** (2.3): `POST /api/v1/accounts/{id}/forecast`, only `enabled` bills, same
  ownership scoping as the rest of the account-nested routes. Also persists the request's
  five params onto the account (`BankAccount.forecast_*`, new migration) as a side effect
  — caught mid-plan-review that the reference client persists these to `localforage` for
  a real reason (pay cycles are ~2 weeks apart, don't make the user re-enter the starting
  balance every visit), so `GET .../accounts/{id}` now returns the last-used settings.
- **Frontend** (2.4): new `/accounts/[id]/forecast` route, form prefilled from the
  account's saved settings, explicit "Calculate" submit (a real API round-trip now, not
  the reference's free client-side recompute-on-keystroke), cycle rows expand in place to
  show bill line items, reference's red/gray negative/low-balance row coloring ported to
  Tailwind, warning banner for any unscheduled bills.

## Test plan

- [x] `cd backend && poetry run pytest` — 50 passed (22 new engine unit tests including
      ported golden values, 6 new API tests, all prior tests still green)
- [x] `cd frontend && yarn run check` — 0 errors
- [x] New Alembic migration applies cleanly (stamp base → upgrade head, all 3 migrations)
- [x] `docker compose` — backend/frontend restart and compile cleanly; headless-browser
      pass shows no console errors, `/accounts/[id]/forecast` route serves without error
- [ ] Manual click-through of the forecast form/results/expand-collapse/warning banner as
      a logged-in user — not done in this session (no login credentials available here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
