### PR TITLE
Phase 3: transactions & windfalls (engine, CRUD APIs, frontend)

### DIFF
--- a/backend/src/api/forecast.py
+++ b/backend/src/api/forecast.py
@@ -42,7 +42,11 @@ async def compute_forecast(
     ]
 
     transactions_result = await db.execute(
-        select(Transaction).where(Transaction.account_id == account.id)
+        select(Transaction).where(
+            Transaction.account_id == account.id,
+            Transaction.date >= payload.start_date,
+            Transaction.date <= payload.end_date,
+        )
     )
     forecast_transactions = [
         ForecastTransaction(
@@ -54,7 +58,13 @@ async def compute_forecast(
         for transaction in transactions_result.scalars().all()
     ]
 
-    windfalls_result = await db.execute(select(Windfall).where(Windfall.account_id == account.id))
+    windfalls_result = await db.execute(
+        select(Windfall).where(
+            Windfall.account_id == account.id,
+            Windfall.expected_date >= payload.start_date,
+            Windfall.expected_date <= payload.end_date,
+        )
+    )
     forecast_windfalls = [
         ForecastWindfall(
             id=windfall.id,

--- a/backend/src/api/forecast.py
+++ b/backend/src/api/forecast.py
@@ -4,13 +4,15 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.api.deps import get_owned_bank_account
 from src.core.database import get_db
-from src.forecast import ForecastBill, get_forecast
-from src.models import BankAccount, Bill
+from src.forecast import ForecastBill, ForecastTransaction, ForecastWindfall, get_forecast
+from src.models import BankAccount, Bill, Transaction, Windfall
 from src.schemas.forecast import (
     ForecastBillLine,
     ForecastCycle,
     ForecastRequest,
     ForecastResponse,
+    ForecastTransactionLine,
+    ForecastWindfallLine,
     UnscheduledBill,
 )
 
@@ -23,7 +25,7 @@ async def compute_forecast(
     db: AsyncSession = Depends(get_db),
     account: BankAccount = Depends(get_owned_bank_account),
 ) -> ForecastResponse:
-    result = await db.execute(
+    bills_result = await db.execute(
         select(Bill).where(Bill.account_id == account.id, Bill.enabled.is_(True))
     )
     forecast_bills = [
@@ -36,7 +38,31 @@ async def compute_forecast(
             start_date=bill.start_date,
             end_date=bill.end_date,
         )
-        for bill in result.scalars().all()
+        for bill in bills_result.scalars().all()
+    ]
+
+    transactions_result = await db.execute(
+        select(Transaction).where(Transaction.account_id == account.id)
+    )
+    forecast_transactions = [
+        ForecastTransaction(
+            id=transaction.id,
+            amount_cents=transaction.amount_cents,
+            date=transaction.date,
+            description=transaction.description,
+        )
+        for transaction in transactions_result.scalars().all()
+    ]
+
+    windfalls_result = await db.execute(select(Windfall).where(Windfall.account_id == account.id))
+    forecast_windfalls = [
+        ForecastWindfall(
+            id=windfall.id,
+            name=windfall.name,
+            amount_cents=windfall.amount_cents,
+            expected_date=windfall.expected_date,
+        )
+        for windfall in windfalls_result.scalars().all()
     ]
 
     forecast = get_forecast(
@@ -46,6 +72,8 @@ async def compute_forecast(
         payload.end_date,
         payload.starting_balance_cents,
         payload.income_per_cycle_cents,
+        transactions=forecast_transactions,
+        windfalls=forecast_windfalls,
     )
 
     # Persist as the account's last-used forecast settings (side effect of an
@@ -74,7 +102,25 @@ async def compute_forecast(
                     )
                     for line in cycle.bills
                 ],
-                cycle_sum_cents=cycle.cycle_sum_cents,
+                transactions=[
+                    ForecastTransactionLine(
+                        transaction_id=line.transaction_id,
+                        amount_cents=line.amount_cents,
+                        date=line.date,
+                        description=line.description,
+                    )
+                    for line in cycle.transactions
+                ],
+                windfalls=[
+                    ForecastWindfallLine(
+                        windfall_id=line.windfall_id,
+                        name=line.name,
+                        amount_cents=line.amount_cents,
+                        expected_date=line.expected_date,
+                    )
+                    for line in cycle.windfalls
+                ],
+                net_cents=cycle.net_cents,
                 running_balance_cents=cycle.running_balance_cents,
             )
             for cycle in forecast.cycles

--- a/backend/src/api/forecast.py
+++ b/backend/src/api/forecast.py
@@ -41,11 +41,17 @@ async def compute_forecast(
         for bill in bills_result.scalars().all()
     ]
 
+    # Only bound the query by start_date, not end_date: no cycle ever starts
+    # before start_date, so anything dated earlier can never appear - but the
+    # final cycle's actual end (computed by get_forecast/_cycle_bounds) can
+    # extend past end_date depending on cycle_type, and bills aren't bounded
+    # by end_date either (occurrences_in_range uses the real cycle end). An
+    # upper bound here would silently drop transactions/windfalls that a bill
+    # due on the same date would still show, corrupting that cycle's net_cents.
     transactions_result = await db.execute(
         select(Transaction).where(
             Transaction.account_id == account.id,
             Transaction.date >= payload.start_date,
-            Transaction.date <= payload.end_date,
         )
     )
     forecast_transactions = [
@@ -62,7 +68,6 @@ async def compute_forecast(
         select(Windfall).where(
             Windfall.account_id == account.id,
             Windfall.expected_date >= payload.start_date,
-            Windfall.expected_date <= payload.end_date,
         )
     )
     forecast_windfalls = [

--- a/backend/src/api/forecast.py
+++ b/backend/src/api/forecast.py
@@ -4,7 +4,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.api.deps import get_owned_bank_account
 from src.core.database import get_db
-from src.forecast import ForecastBill, ForecastTransaction, ForecastWindfall, get_forecast
+from src.forecast import (
+    ForecastBill,
+    ForecastTransaction,
+    ForecastWindfall,
+    get_forecast,
+    last_cycle_end,
+)
 from src.models import BankAccount, Bill, Transaction, Windfall
 from src.schemas.forecast import (
     ForecastBillLine,
@@ -41,17 +47,20 @@ async def compute_forecast(
         for bill in bills_result.scalars().all()
     ]
 
-    # Only bound the query by start_date, not end_date: no cycle ever starts
-    # before start_date, so anything dated earlier can never appear - but the
-    # final cycle's actual end (computed by get_forecast/_cycle_bounds) can
-    # extend past end_date depending on cycle_type, and bills aren't bounded
-    # by end_date either (occurrences_in_range uses the real cycle end). An
-    # upper bound here would silently drop transactions/windfalls that a bill
-    # due on the same date would still show, corrupting that cycle's net_cents.
+    # Bound the query to [start_date, last cycle's actual end]: no cycle ever
+    # starts before start_date, and the final cycle can run past end_date
+    # depending on cycle_type (see _cycle_bounds) - using end_date directly
+    # as the upper bound would silently drop transactions/windfalls that a
+    # bill due on the same date would still show, corrupting that cycle's
+    # net_cents. last_cycle_end() computes the real bound the same way
+    # get_forecast() will.
+    query_end_date = last_cycle_end(payload.cycle_type, payload.start_date, payload.end_date)
+
     transactions_result = await db.execute(
         select(Transaction).where(
             Transaction.account_id == account.id,
             Transaction.date >= payload.start_date,
+            Transaction.date <= query_end_date,
         )
     )
     forecast_transactions = [
@@ -68,6 +77,7 @@ async def compute_forecast(
         select(Windfall).where(
             Windfall.account_id == account.id,
             Windfall.expected_date >= payload.start_date,
+            Windfall.expected_date <= query_end_date,
         )
     )
     forecast_windfalls = [

--- a/backend/src/api/transactions.py
+++ b/backend/src/api/transactions.py
@@ -55,7 +55,11 @@ async def list_transactions(
     db: AsyncSession = Depends(get_db),
     account: BankAccount = Depends(get_owned_bank_account),
 ) -> list[Transaction]:
-    result = await db.execute(select(Transaction).where(Transaction.account_id == account.id))
+    result = await db.execute(
+        select(Transaction)
+        .where(Transaction.account_id == account.id)
+        .order_by(Transaction.date.desc(), Transaction.id.desc())
+    )
     return list(result.scalars().all())
 
 

--- a/backend/src/api/transactions.py
+++ b/backend/src/api/transactions.py
@@ -26,6 +26,22 @@ async def _get_owned_transaction(
     return transaction
 
 
+_NON_NULLABLE_UPDATE_FIELDS = ("amount_cents", "date")
+
+
+def _reject_explicit_nulls(update_data: dict) -> None:
+    nulled = [
+        field
+        for field in _NON_NULLABLE_UPDATE_FIELDS
+        if field in update_data and update_data[field] is None
+    ]
+    if nulled:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Field(s) cannot be null: {', '.join(nulled)}",
+        )
+
+
 async def _validate_bill_id(bill_id: int | None, account_id: int, db: AsyncSession) -> None:
     if bill_id is None:
         return
@@ -65,6 +81,7 @@ async def update_transaction(
     transaction: Transaction = Depends(_get_owned_transaction),
 ) -> Transaction:
     update_data = payload.model_dump(exclude_unset=True)
+    _reject_explicit_nulls(update_data)
     if "bill_id" in update_data:
         await _validate_bill_id(update_data["bill_id"], account.id, db)
     for field, value in update_data.items():

--- a/backend/src/api/transactions.py
+++ b/backend/src/api/transactions.py
@@ -1,0 +1,83 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.api.deps import get_owned_bank_account
+from src.core.database import get_db
+from src.models import BankAccount, Bill, Transaction
+from src.schemas.transaction import TransactionCreate, TransactionRead, TransactionUpdate
+
+router = APIRouter(prefix="/api/v1/accounts/{account_id}/transactions", tags=["transactions"])
+
+
+async def _get_owned_transaction(
+    transaction_id: int,
+    db: AsyncSession = Depends(get_db),
+    account: BankAccount = Depends(get_owned_bank_account),
+) -> Transaction:
+    result = await db.execute(
+        select(Transaction).where(
+            Transaction.id == transaction_id, Transaction.account_id == account.id
+        )
+    )
+    transaction = result.scalar_one_or_none()
+    if transaction is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Transaction not found")
+    return transaction
+
+
+async def _validate_bill_id(bill_id: int | None, account_id: int, db: AsyncSession) -> None:
+    if bill_id is None:
+        return
+    result = await db.execute(select(Bill).where(Bill.id == bill_id, Bill.account_id == account_id))
+    if result.scalar_one_or_none() is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Bill not found")
+
+
+@router.get("", response_model=list[TransactionRead])
+async def list_transactions(
+    db: AsyncSession = Depends(get_db),
+    account: BankAccount = Depends(get_owned_bank_account),
+) -> list[Transaction]:
+    result = await db.execute(select(Transaction).where(Transaction.account_id == account.id))
+    return list(result.scalars().all())
+
+
+@router.post("", response_model=TransactionRead, status_code=status.HTTP_201_CREATED)
+async def create_transaction(
+    payload: TransactionCreate,
+    db: AsyncSession = Depends(get_db),
+    account: BankAccount = Depends(get_owned_bank_account),
+) -> Transaction:
+    await _validate_bill_id(payload.bill_id, account.id, db)
+    transaction = Transaction(account_id=account.id, **payload.model_dump())
+    db.add(transaction)
+    await db.commit()
+    await db.refresh(transaction)
+    return transaction
+
+
+@router.patch("/{transaction_id}", response_model=TransactionRead)
+async def update_transaction(
+    payload: TransactionUpdate,
+    db: AsyncSession = Depends(get_db),
+    account: BankAccount = Depends(get_owned_bank_account),
+    transaction: Transaction = Depends(_get_owned_transaction),
+) -> Transaction:
+    update_data = payload.model_dump(exclude_unset=True)
+    if "bill_id" in update_data:
+        await _validate_bill_id(update_data["bill_id"], account.id, db)
+    for field, value in update_data.items():
+        setattr(transaction, field, value)
+    await db.commit()
+    await db.refresh(transaction)
+    return transaction
+
+
+@router.delete("/{transaction_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_transaction(
+    db: AsyncSession = Depends(get_db),
+    transaction: Transaction = Depends(_get_owned_transaction),
+) -> None:
+    await db.delete(transaction)
+    await db.commit()

--- a/backend/src/api/windfalls.py
+++ b/backend/src/api/windfalls.py
@@ -44,7 +44,11 @@ async def list_windfalls(
     db: AsyncSession = Depends(get_db),
     account: BankAccount = Depends(get_owned_bank_account),
 ) -> list[Windfall]:
-    result = await db.execute(select(Windfall).where(Windfall.account_id == account.id))
+    result = await db.execute(
+        select(Windfall)
+        .where(Windfall.account_id == account.id)
+        .order_by(Windfall.expected_date.asc(), Windfall.id.asc())
+    )
     return list(result.scalars().all())
 
 

--- a/backend/src/api/windfalls.py
+++ b/backend/src/api/windfalls.py
@@ -9,6 +9,21 @@ from src.schemas.windfall import WindfallCreate, WindfallRead, WindfallUpdate
 
 router = APIRouter(prefix="/api/v1/accounts/{account_id}/windfalls", tags=["windfalls"])
 
+_NON_NULLABLE_UPDATE_FIELDS = ("name", "amount_cents", "expected_date")
+
+
+def _reject_explicit_nulls(update_data: dict) -> None:
+    nulled = [
+        field
+        for field in _NON_NULLABLE_UPDATE_FIELDS
+        if field in update_data and update_data[field] is None
+    ]
+    if nulled:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Field(s) cannot be null: {', '.join(nulled)}",
+        )
+
 
 async def _get_owned_windfall(
     windfall_id: int,
@@ -52,7 +67,9 @@ async def update_windfall(
     db: AsyncSession = Depends(get_db),
     windfall: Windfall = Depends(_get_owned_windfall),
 ) -> Windfall:
-    for field, value in payload.model_dump(exclude_unset=True).items():
+    update_data = payload.model_dump(exclude_unset=True)
+    _reject_explicit_nulls(update_data)
+    for field, value in update_data.items():
         setattr(windfall, field, value)
     await db.commit()
     await db.refresh(windfall)

--- a/backend/src/api/windfalls.py
+++ b/backend/src/api/windfalls.py
@@ -1,0 +1,68 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.api.deps import get_owned_bank_account
+from src.core.database import get_db
+from src.models import BankAccount, Windfall
+from src.schemas.windfall import WindfallCreate, WindfallRead, WindfallUpdate
+
+router = APIRouter(prefix="/api/v1/accounts/{account_id}/windfalls", tags=["windfalls"])
+
+
+async def _get_owned_windfall(
+    windfall_id: int,
+    db: AsyncSession = Depends(get_db),
+    account: BankAccount = Depends(get_owned_bank_account),
+) -> Windfall:
+    result = await db.execute(
+        select(Windfall).where(Windfall.id == windfall_id, Windfall.account_id == account.id)
+    )
+    windfall = result.scalar_one_or_none()
+    if windfall is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Windfall not found")
+    return windfall
+
+
+@router.get("", response_model=list[WindfallRead])
+async def list_windfalls(
+    db: AsyncSession = Depends(get_db),
+    account: BankAccount = Depends(get_owned_bank_account),
+) -> list[Windfall]:
+    result = await db.execute(select(Windfall).where(Windfall.account_id == account.id))
+    return list(result.scalars().all())
+
+
+@router.post("", response_model=WindfallRead, status_code=status.HTTP_201_CREATED)
+async def create_windfall(
+    payload: WindfallCreate,
+    db: AsyncSession = Depends(get_db),
+    account: BankAccount = Depends(get_owned_bank_account),
+) -> Windfall:
+    windfall = Windfall(account_id=account.id, **payload.model_dump())
+    db.add(windfall)
+    await db.commit()
+    await db.refresh(windfall)
+    return windfall
+
+
+@router.patch("/{windfall_id}", response_model=WindfallRead)
+async def update_windfall(
+    payload: WindfallUpdate,
+    db: AsyncSession = Depends(get_db),
+    windfall: Windfall = Depends(_get_owned_windfall),
+) -> Windfall:
+    for field, value in payload.model_dump(exclude_unset=True).items():
+        setattr(windfall, field, value)
+    await db.commit()
+    await db.refresh(windfall)
+    return windfall
+
+
+@router.delete("/{windfall_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_windfall(
+    db: AsyncSession = Depends(get_db),
+    windfall: Windfall = Depends(_get_owned_windfall),
+) -> None:
+    await db.delete(windfall)
+    await db.commit()

--- a/backend/src/forecast/__init__.py
+++ b/backend/src/forecast/__init__.py
@@ -1,13 +1,25 @@
 from src.forecast.bill import ForecastBill, MissingRecurrenceConfig
-from src.forecast.cycle import Cycle, CycleBillLine, build_cycle
+from src.forecast.cycle import (
+    Cycle,
+    CycleBillLine,
+    CycleTransactionLine,
+    CycleWindfallLine,
+    build_cycle,
+)
 from src.forecast.engine import ForecastCycle, ForecastResult, UnscheduledBill, get_forecast
+from src.forecast.transaction import ForecastTransaction
+from src.forecast.windfall import ForecastWindfall
 
 __all__ = [
     "Cycle",
     "CycleBillLine",
+    "CycleTransactionLine",
+    "CycleWindfallLine",
     "ForecastBill",
     "ForecastCycle",
     "ForecastResult",
+    "ForecastTransaction",
+    "ForecastWindfall",
     "MissingRecurrenceConfig",
     "UnscheduledBill",
     "build_cycle",

--- a/backend/src/forecast/__init__.py
+++ b/backend/src/forecast/__init__.py
@@ -6,7 +6,13 @@ from src.forecast.cycle import (
     CycleWindfallLine,
     build_cycle,
 )
-from src.forecast.engine import ForecastCycle, ForecastResult, UnscheduledBill, get_forecast
+from src.forecast.engine import (
+    ForecastCycle,
+    ForecastResult,
+    UnscheduledBill,
+    get_forecast,
+    last_cycle_end,
+)
 from src.forecast.transaction import ForecastTransaction
 from src.forecast.windfall import ForecastWindfall
 
@@ -24,4 +30,5 @@ __all__ = [
     "UnscheduledBill",
     "build_cycle",
     "get_forecast",
+    "last_cycle_end",
 ]

--- a/backend/src/forecast/cycle.py
+++ b/backend/src/forecast/cycle.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 from datetime import date
 
 from src.forecast.bill import ForecastBill, occurrences_in_range
+from src.forecast.transaction import ForecastTransaction
+from src.forecast.windfall import ForecastWindfall
 
 
 @dataclass
@@ -15,22 +17,51 @@ class CycleBillLine:
 
 
 @dataclass
+class CycleTransactionLine:
+    transaction_id: int
+    amount_cents: int
+    date: date
+    description: str | None
+
+
+@dataclass
+class CycleWindfallLine:
+    windfall_id: int
+    name: str
+    amount_cents: int
+    expected_date: date
+
+
+@dataclass
 class Cycle:
     bills: list[CycleBillLine]
-    sum_cents: int
+    transactions: list[CycleTransactionLine]
+    windfalls: list[CycleWindfallLine]
+    # Net balance impact for this cycle: transactions (signed) + windfalls
+    # (always positive) - bills (always positive, always an expense).
+    net_cents: int
 
 
-def build_cycle(bills: list[ForecastBill], start: date, end: date) -> Cycle:
-    """Bills due within [start, end], sorted by due date, with the total.
+def build_cycle(
+    bills: list[ForecastBill],
+    transactions: list[ForecastTransaction],
+    windfalls: list[ForecastWindfall],
+    start: date,
+    end: date,
+) -> Cycle:
+    """Bills/transactions/windfalls falling within [start, end], each sorted
+    by date, plus the combined net balance impact.
 
     `bills` must already be pre-filtered to ones with valid recurrence_config
     (see validate_recurrence_config) - this raises MissingRecurrenceConfig
-    otherwise, same as occurrences_in_range.
+    otherwise, same as occurrences_in_range. Transactions and windfalls are
+    one-off (a single date each), so unlike bills there's no recurrence/
+    due-date computation - just a plain date-range check.
     """
-    lines: list[CycleBillLine] = []
+    bill_lines: list[CycleBillLine] = []
     for bill in bills:
         for occurrence in occurrences_in_range(bill, start, end):
-            lines.append(
+            bill_lines.append(
                 CycleBillLine(
                     bill_id=bill.id,
                     name=bill.name,
@@ -38,6 +69,40 @@ def build_cycle(bills: list[ForecastBill], start: date, end: date) -> Cycle:
                     due_date=occurrence,
                 )
             )
-    lines.sort(key=lambda line: (line.due_date, line.bill_id))
-    total = sum(line.amount_cents for line in lines)
-    return Cycle(bills=lines, sum_cents=total)
+    bill_lines.sort(key=lambda line: (line.due_date, line.bill_id))
+    bills_total = sum(line.amount_cents for line in bill_lines)
+
+    transaction_lines = [
+        CycleTransactionLine(
+            transaction_id=t.id,
+            amount_cents=t.amount_cents,
+            date=t.date,
+            description=t.description,
+        )
+        for t in transactions
+        if start <= t.date <= end
+    ]
+    transaction_lines.sort(key=lambda line: (line.date, line.transaction_id))
+    transactions_total = sum(line.amount_cents for line in transaction_lines)
+
+    windfall_lines = [
+        CycleWindfallLine(
+            windfall_id=w.id,
+            name=w.name,
+            amount_cents=w.amount_cents,
+            expected_date=w.expected_date,
+        )
+        for w in windfalls
+        if start <= w.expected_date <= end
+    ]
+    windfall_lines.sort(key=lambda line: (line.expected_date, line.windfall_id))
+    windfalls_total = sum(line.amount_cents for line in windfall_lines)
+
+    net_cents = transactions_total + windfalls_total - bills_total
+
+    return Cycle(
+        bills=bill_lines,
+        transactions=transaction_lines,
+        windfalls=windfall_lines,
+        net_cents=net_cents,
+    )

--- a/backend/src/forecast/engine.py
+++ b/backend/src/forecast/engine.py
@@ -118,7 +118,10 @@ def last_cycle_end(cycle_type: CycleType, start_date: date, end_date: date) -> d
     cycle could touch" (e.g. an upper bound for loading transactions/
     windfalls) should use this instead of end_date directly.
     """
-    *_, (_, last_end) = _iter_cycle_bounds(cycle_type, start_date, end_date)
+    last_end: date | None = None
+    for _, current_end in _iter_cycle_bounds(cycle_type, start_date, end_date):
+        last_end = current_end
+    assert last_end is not None  # _iter_cycle_bounds always yields at least one cycle
     return last_end
 
 

--- a/backend/src/forecast/engine.py
+++ b/backend/src/forecast/engine.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from calendar import monthrange
+from collections.abc import Iterator
 from dataclasses import dataclass
 from datetime import date, timedelta
 
@@ -91,6 +92,36 @@ def _cycle_bounds(cycle_type: CycleType, start: date) -> tuple[date, date]:
     raise ValueError(f"Unsupported cycle type: {cycle_type}")  # pragma: no cover
 
 
+def _iter_cycle_bounds(
+    cycle_type: CycleType, start_date: date, end_date: date
+) -> Iterator[tuple[date, date]]:
+    """Yields (cycle_start, cycle_end) for each cycle get_forecast() would
+    generate between start_date and end_date. Shared by get_forecast() and
+    last_cycle_end() so both agree on exactly where cycles fall.
+    """
+    if end_date < start_date:
+        raise ValueError("end_date must be on or after start_date")
+
+    current_start = start_date
+    while current_start <= end_date:
+        current_end, next_start = _cycle_bounds(cycle_type, current_start)
+        yield current_start, current_end
+        current_start = next_start
+
+
+def last_cycle_end(cycle_type: CycleType, start_date: date, end_date: date) -> date:
+    """The end date of the last cycle get_forecast() would generate for the
+    same (cycle_type, start_date, end_date).
+
+    Cycles don't snap to end_date, so the final one can run past it (see
+    _cycle_bounds) - callers that need to bound a query to "every date any
+    cycle could touch" (e.g. an upper bound for loading transactions/
+    windfalls) should use this instead of end_date directly.
+    """
+    *_, (_, last_end) = _iter_cycle_bounds(cycle_type, start_date, end_date)
+    return last_end
+
+
 def get_forecast(
     bills: list[ForecastBill],
     cycle_type: CycleType,
@@ -101,9 +132,6 @@ def get_forecast(
     transactions: list[ForecastTransaction] | None = None,
     windfalls: list[ForecastWindfall] | None = None,
 ) -> ForecastResult:
-    if end_date < start_date:
-        raise ValueError("end_date must be on or after start_date")
-
     transactions = transactions or []
     windfalls = windfalls or []
 
@@ -116,12 +144,10 @@ def get_forecast(
         else:
             schedulable.append(bill)
 
-    current_start = start_date
     running_balance = starting_balance_cents
     cycles: list[ForecastCycle] = []
 
-    while current_start <= end_date:
-        current_end, next_start = _cycle_bounds(cycle_type, current_start)
+    for current_start, current_end in _iter_cycle_bounds(cycle_type, start_date, end_date):
         cycle = build_cycle(schedulable, transactions, windfalls, current_start, current_end)
         running_balance += income_per_cycle_cents + cycle.net_cents
         cycles.append(
@@ -135,7 +161,6 @@ def get_forecast(
                 running_balance_cents=running_balance,
             )
         )
-        current_start = next_start
 
     return ForecastResult(
         cycles=cycles,

--- a/backend/src/forecast/engine.py
+++ b/backend/src/forecast/engine.py
@@ -5,7 +5,14 @@ from dataclasses import dataclass
 from datetime import date, timedelta
 
 from src.forecast.bill import ForecastBill, validate_recurrence_config
-from src.forecast.cycle import CycleBillLine, build_cycle
+from src.forecast.cycle import (
+    CycleBillLine,
+    CycleTransactionLine,
+    CycleWindfallLine,
+    build_cycle,
+)
+from src.forecast.transaction import ForecastTransaction
+from src.forecast.windfall import ForecastWindfall
 from src.models.bank_account import CycleType
 
 
@@ -21,7 +28,9 @@ class ForecastCycle:
     start_date: date
     end_date: date
     bills: list[CycleBillLine]
-    cycle_sum_cents: int
+    transactions: list[CycleTransactionLine]
+    windfalls: list[CycleWindfallLine]
+    net_cents: int
     running_balance_cents: int
 
 
@@ -89,9 +98,14 @@ def get_forecast(
     end_date: date,
     starting_balance_cents: int,
     income_per_cycle_cents: int,
+    transactions: list[ForecastTransaction] | None = None,
+    windfalls: list[ForecastWindfall] | None = None,
 ) -> ForecastResult:
     if end_date < start_date:
         raise ValueError("end_date must be on or after start_date")
+
+    transactions = transactions or []
+    windfalls = windfalls or []
 
     schedulable: list[ForecastBill] = []
     unscheduled: list[UnscheduledBill] = []
@@ -108,17 +122,16 @@ def get_forecast(
 
     while current_start <= end_date:
         current_end, next_start = _cycle_bounds(cycle_type, current_start)
-        cycle = build_cycle(schedulable, current_start, current_end)
-        # Bills are stored (and displayed) as positive amounts throughout Tally
-        # (see Bill.amount_cents) - unlike the reference engine, which stores
-        # bill amounts pre-negated, so cycle sums subtract here instead of add.
-        running_balance += income_per_cycle_cents - cycle.sum_cents
+        cycle = build_cycle(schedulable, transactions, windfalls, current_start, current_end)
+        running_balance += income_per_cycle_cents + cycle.net_cents
         cycles.append(
             ForecastCycle(
                 start_date=current_start,
                 end_date=current_end,
                 bills=cycle.bills,
-                cycle_sum_cents=cycle.sum_cents,
+                transactions=cycle.transactions,
+                windfalls=cycle.windfalls,
+                net_cents=cycle.net_cents,
                 running_balance_cents=running_balance,
             )
         )

--- a/backend/src/forecast/transaction.py
+++ b/backend/src/forecast/transaction.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+
+
+@dataclass
+class ForecastTransaction:
+    """A one-off ledger entry, decoupled from the SQLAlchemy model (matches
+    ForecastBill's pattern). Unlike a Bill (always a positive expense) or a
+    Windfall (always positive income), amount_cents is signed: positive
+    credits the balance, negative debits it - a Transaction is the
+    general-purpose one-off entry, not restricted to either direction."""
+
+    id: int
+    amount_cents: int
+    date: date
+    description: str | None

--- a/backend/src/forecast/windfall.py
+++ b/backend/src/forecast/windfall.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+
+
+@dataclass
+class ForecastWindfall:
+    """A one-time future income event (bonus, tax refund, etc.), decoupled
+    from the SQLAlchemy model. amount_cents is always positive - a windfall
+    is income by definition, unlike the signed ForecastTransaction."""
+
+    id: int
+    name: str
+    amount_cents: int
+    expected_date: date

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -2,7 +2,7 @@ from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from mangum import Mangum
 
-from src.api import accounts, bills, forecast
+from src.api import accounts, bills, forecast, transactions, windfalls
 from src.core.auth import get_current_user
 
 app = FastAPI()
@@ -10,6 +10,8 @@ app = FastAPI()
 app.include_router(accounts.router)
 app.include_router(bills.router)
 app.include_router(forecast.router)
+app.include_router(transactions.router)
+app.include_router(windfalls.router)
 
 # Only needed for local dev: the frontend (:5173) and backend (:8000) run on
 # different origins there. In prod they share an origin via CloudFront's

--- a/backend/src/schemas/forecast.py
+++ b/backend/src/schemas/forecast.py
@@ -28,11 +28,27 @@ class ForecastBillLine(BaseModel):
     due_date: date
 
 
+class ForecastTransactionLine(BaseModel):
+    transaction_id: int
+    amount_cents: int
+    date: date
+    description: str | None
+
+
+class ForecastWindfallLine(BaseModel):
+    windfall_id: int
+    name: str
+    amount_cents: int
+    expected_date: date
+
+
 class ForecastCycle(BaseModel):
     start_date: date
     end_date: date
     bills: list[ForecastBillLine]
-    cycle_sum_cents: int
+    transactions: list[ForecastTransactionLine]
+    windfalls: list[ForecastWindfallLine]
+    net_cents: int
     running_balance_cents: int
 
 

--- a/backend/src/schemas/transaction.py
+++ b/backend/src/schemas/transaction.py
@@ -1,0 +1,40 @@
+from datetime import date as date_
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+# The Transaction model's date column is named `date`, matching the field
+# name below - so `date` is imported under an alias (`date_`) to avoid a
+# real Python gotcha: `date: date | None = None` self-shadows, since the
+# default value (None) gets bound to the name `date` in the class body
+# *before* the `date | None` annotation expression is evaluated, and that
+# corrupted local persists even under `from __future__ import annotations`
+# (Pydantic's forward-ref resolution consults the class's own namespace).
+
+
+class TransactionCreate(BaseModel):
+    # Signed: positive credits the balance, negative debits it - unlike Bill
+    # (always a positive expense) a transaction is general-purpose.
+    amount_cents: int
+    date: date_
+    description: str | None = None
+    bill_id: int | None = None
+
+
+class TransactionUpdate(BaseModel):
+    amount_cents: int | None = None
+    date: date_ | None = None
+    description: str | None = None
+    bill_id: int | None = None
+
+
+class TransactionRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    account_id: int
+    bill_id: int | None
+    amount_cents: int
+    date: date_
+    description: str | None
+    created_at: datetime

--- a/backend/src/schemas/windfall.py
+++ b/backend/src/schemas/windfall.py
@@ -1,18 +1,18 @@
 from datetime import date, datetime
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class WindfallCreate(BaseModel):
     name: str
     # Always positive - a windfall is income by definition.
-    amount_cents: int
+    amount_cents: int = Field(gt=0)
     expected_date: date
 
 
 class WindfallUpdate(BaseModel):
     name: str | None = None
-    amount_cents: int | None = None
+    amount_cents: int | None = Field(default=None, gt=0)
     expected_date: date | None = None
 
 

--- a/backend/src/schemas/windfall.py
+++ b/backend/src/schemas/windfall.py
@@ -1,0 +1,27 @@
+from datetime import date, datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class WindfallCreate(BaseModel):
+    name: str
+    # Always positive - a windfall is income by definition.
+    amount_cents: int
+    expected_date: date
+
+
+class WindfallUpdate(BaseModel):
+    name: str | None = None
+    amount_cents: int | None = None
+    expected_date: date | None = None
+
+
+class WindfallRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    account_id: int
+    name: str
+    amount_cents: int
+    expected_date: date
+    created_at: datetime

--- a/backend/tests/test_forecast_api.py
+++ b/backend/tests/test_forecast_api.py
@@ -62,6 +62,32 @@ async def test_forecast_computes_cycles_and_running_balance(client: AsyncClient)
     assert body["unscheduled_bills"] == []
 
 
+async def test_forecast_includes_transactions_and_windfalls(client: AsyncClient):
+    account = await _create_account(client)
+    await client.post(f"/api/v1/accounts/{account['id']}/bills", json=_bill_payload())
+    await client.post(
+        f"/api/v1/accounts/{account['id']}/transactions",
+        json={"amount_cents": -2000, "date": "2024-01-10", "description": "oops"},
+    )
+    await client.post(
+        f"/api/v1/accounts/{account['id']}/windfalls",
+        json={"name": "bonus", "amount_cents": 50000, "expected_date": "2024-01-20"},
+    )
+
+    res = await client.post(
+        f"/api/v1/accounts/{account['id']}/forecast",
+        json=_forecast_payload(end_date="2024-01-31"),
+    )
+    assert res.status_code == 200
+    body = res.json()
+    first_cycle = body["cycles"][0]
+    assert len(first_cycle["transactions"]) == 1
+    assert len(first_cycle["windfalls"]) == 1
+    # -150000 (bill) - 2000 (transaction) + 50000 (windfall)
+    assert first_cycle["net_cents"] == -102000
+    assert body["ending_balance_cents"] == 100000 + 200000 - 102000
+
+
 async def test_forecast_excludes_disabled_bills(client: AsyncClient):
     account = await _create_account(client)
     await client.post(

--- a/backend/tests/test_forecast_engine.py
+++ b/backend/tests/test_forecast_engine.py
@@ -29,7 +29,14 @@ from datetime import date
 
 import pytest
 
-from src.forecast import ForecastBill, MissingRecurrenceConfig, build_cycle, get_forecast
+from src.forecast import (
+    ForecastBill,
+    ForecastTransaction,
+    ForecastWindfall,
+    MissingRecurrenceConfig,
+    build_cycle,
+    get_forecast,
+)
 from src.forecast.bill import occurrences_in_range, validate_recurrence_config
 from src.models.bank_account import CycleType
 from src.models.bill import RecurrenceType
@@ -180,11 +187,16 @@ class TestCycleGoldenValue:
             make_bill(2, "bill two", 1525, date(1985, 10, 22)),
             make_bill(3, "bill three", 1525, date(1985, 10, 23)),
         ]
-        cycle_one = build_cycle(bills, date(1985, 10, 21), date(1985, 10, 28))
-        cycle_two = build_cycle(bills, date(1985, 11, 21), date(1985, 11, 28))
+        cycle_one = build_cycle(bills, [], [], date(1985, 10, 21), date(1985, 10, 28))
+        cycle_two = build_cycle(bills, [], [], date(1985, 11, 21), date(1985, 11, 28))
 
         assert len(cycle_one.bills) != len(cycle_two.bills)
-        assert cycle_one.sum_cents + cycle_two.sum_cents == 7625
+        # net_cents is negative for bills-only cycles (bills are expenses,
+        # subtracted) - the reference's golden value (-76.25, its bills are
+        # stored pre-negated) matches this sign directly, unlike the other
+        # ported fixtures which had to flip sign for Tally's positive-amount
+        # convention.
+        assert cycle_one.net_cents + cycle_two.net_cents == -7625
 
 
 class TestDueDateMonthEndClamping:
@@ -268,3 +280,59 @@ class TestGetForecastValidation:
         # there) - a forecast for a single day should still show that day.
         result = get_forecast([], CycleType.MONTHLY, date(2024, 1, 1), date(2024, 1, 1), 0, 0)
         assert len(result.cycles) == 1
+
+
+class TestGetForecastTransactionsAndWindfalls:
+    def test_windfall_adds_to_running_balance(self):
+        windfall = ForecastWindfall(id=1, name="tax refund", amount_cents=50000, expected_date=date(2024, 1, 15))
+        result = get_forecast(
+            [], CycleType.MONTHLY, date(2024, 1, 1), date(2024, 1, 31), 0, 0, windfalls=[windfall]
+        )
+        assert len(result.cycles[0].windfalls) == 1
+        assert result.cycles[0].net_cents == 50000
+        assert result.ending_balance_cents == 50000
+
+    def test_positive_transaction_credits_negative_transaction_debits(self):
+        credit = ForecastTransaction(id=1, amount_cents=10000, date=date(2024, 1, 5), description="refund")
+        debit = ForecastTransaction(id=2, amount_cents=-3000, date=date(2024, 1, 10), description="oops")
+        result = get_forecast(
+            [], CycleType.MONTHLY, date(2024, 1, 1), date(2024, 1, 31), 0, 0, transactions=[credit, debit]
+        )
+        assert len(result.cycles[0].transactions) == 2
+        assert result.cycles[0].net_cents == 7000
+        assert result.ending_balance_cents == 7000
+
+    def test_bills_transactions_and_windfalls_combine_in_one_cycle(self):
+        bill = make_bill(1, "rent", 150000, date(2024, 1, 1))
+        transaction = ForecastTransaction(id=1, amount_cents=-2000, date=date(2024, 1, 10), description=None)
+        windfall = ForecastWindfall(id=1, name="bonus", amount_cents=100000, expected_date=date(2024, 1, 20))
+        result = get_forecast(
+            [bill],
+            CycleType.MONTHLY,
+            date(2024, 1, 1),
+            date(2024, 1, 31),
+            0,
+            0,
+            transactions=[transaction],
+            windfalls=[windfall],
+        )
+        # -150000 (bill) - 2000 (transaction) + 100000 (windfall)
+        assert result.cycles[0].net_cents == -52000
+        assert result.ending_balance_cents == -52000
+
+    def test_transaction_and_windfall_outside_cycle_window_excluded(self):
+        transaction = ForecastTransaction(id=1, amount_cents=10000, date=date(2024, 2, 1), description=None)
+        windfall = ForecastWindfall(id=1, name="late", amount_cents=5000, expected_date=date(2024, 2, 1))
+        result = get_forecast(
+            [],
+            CycleType.MONTHLY,
+            date(2024, 1, 1),
+            date(2024, 1, 31),
+            0,
+            0,
+            transactions=[transaction],
+            windfalls=[windfall],
+        )
+        assert result.cycles[0].transactions == []
+        assert result.cycles[0].windfalls == []
+        assert result.cycles[0].net_cents == 0

--- a/backend/tests/test_forecast_engine.py
+++ b/backend/tests/test_forecast_engine.py
@@ -36,6 +36,7 @@ from src.forecast import (
     MissingRecurrenceConfig,
     build_cycle,
     get_forecast,
+    last_cycle_end,
 )
 from src.forecast.bill import occurrences_in_range, validate_recurrence_config
 from src.models.bank_account import CycleType
@@ -280,6 +281,22 @@ class TestGetForecastValidation:
         # there) - a forecast for a single day should still show that day.
         result = get_forecast([], CycleType.MONTHLY, date(2024, 1, 1), date(2024, 1, 1), 0, 0)
         assert len(result.cycles) == 1
+
+
+class TestLastCycleEnd:
+    def test_matches_final_cycle_end_date_from_get_forecast(self):
+        # Weekly cycles are 7 days - a 10-day window's last cycle necessarily
+        # runs past end_date, which is exactly the case last_cycle_end exists
+        # to compute correctly for query-bounding callers.
+        start = date(2024, 1, 1)
+        end = date(2024, 1, 10)
+        result = get_forecast([], CycleType.WEEKLY, start, end, 0, 0)
+        assert last_cycle_end(CycleType.WEEKLY, start, end) == result.cycles[-1].end_date
+        assert result.cycles[-1].end_date > end
+
+    def test_end_date_before_start_date_raises(self):
+        with pytest.raises(ValueError):
+            last_cycle_end(CycleType.MONTHLY, date(2024, 2, 1), date(2024, 1, 1))
 
 
 class TestGetForecastTransactionsAndWindfalls:

--- a/backend/tests/test_transactions_api.py
+++ b/backend/tests/test_transactions_api.py
@@ -1,0 +1,138 @@
+import pytest
+from httpx import AsyncClient
+
+from src.core.auth import get_current_user
+from src.main import app
+from tests.conftest import auth_as
+
+
+def _login_as(sub: str) -> None:
+    app.dependency_overrides[get_current_user] = auth_as(sub)
+
+
+@pytest.fixture(autouse=True)
+def _default_user():
+    _login_as("auth0|owner")
+    yield
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+async def _create_account(client: AsyncClient) -> dict:
+    res = await client.post("/api/v1/accounts", json={"name": "Checking"})
+    return res.json()
+
+
+def _transaction_payload(**overrides) -> dict:
+    payload = {
+        "amount_cents": -2500,
+        "date": "2024-01-15",
+        "description": "Coffee",
+    }
+    payload.update(overrides)
+    return payload
+
+
+async def test_create_and_list_transactions(client: AsyncClient):
+    account = await _create_account(client)
+
+    res = await client.post(
+        f"/api/v1/accounts/{account['id']}/transactions", json=_transaction_payload()
+    )
+    assert res.status_code == 201
+    body = res.json()
+    assert body["amount_cents"] == -2500
+    assert body["description"] == "Coffee"
+    assert body["bill_id"] is None
+
+    res = await client.get(f"/api/v1/accounts/{account['id']}/transactions")
+    assert res.status_code == 200
+    assert len(res.json()) == 1
+
+
+async def test_update_transaction(client: AsyncClient):
+    account = await _create_account(client)
+    transaction = (
+        await client.post(
+            f"/api/v1/accounts/{account['id']}/transactions", json=_transaction_payload()
+        )
+    ).json()
+
+    res = await client.patch(
+        f"/api/v1/accounts/{account['id']}/transactions/{transaction['id']}",
+        json={"amount_cents": 500},
+    )
+    assert res.status_code == 200
+    assert res.json()["amount_cents"] == 500
+
+
+async def test_delete_transaction(client: AsyncClient):
+    account = await _create_account(client)
+    transaction = (
+        await client.post(
+            f"/api/v1/accounts/{account['id']}/transactions", json=_transaction_payload()
+        )
+    ).json()
+
+    res = await client.delete(f"/api/v1/accounts/{account['id']}/transactions/{transaction['id']}")
+    assert res.status_code == 204
+
+    res = await client.get(f"/api/v1/accounts/{account['id']}/transactions")
+    assert res.json() == []
+
+
+async def test_transaction_can_link_to_a_bill_in_the_same_account(client: AsyncClient):
+    account = await _create_account(client)
+    bill = (
+        await client.post(
+            f"/api/v1/accounts/{account['id']}/bills",
+            json={
+                "name": "Rent",
+                "amount_cents": 150000,
+                "recurrence_type": "monthly",
+                "start_date": "2024-01-01",
+            },
+        )
+    ).json()
+
+    res = await client.post(
+        f"/api/v1/accounts/{account['id']}/transactions",
+        json=_transaction_payload(bill_id=bill["id"]),
+    )
+    assert res.status_code == 201
+    assert res.json()["bill_id"] == bill["id"]
+
+
+async def test_transaction_cannot_link_to_a_bill_in_another_account(client: AsyncClient):
+    account = await _create_account(client)
+    other_account = (await client.post("/api/v1/accounts", json={"name": "Savings"})).json()
+    other_bill = (
+        await client.post(
+            f"/api/v1/accounts/{other_account['id']}/bills",
+            json={
+                "name": "Rent",
+                "amount_cents": 150000,
+                "recurrence_type": "monthly",
+                "start_date": "2024-01-01",
+            },
+        )
+    ).json()
+
+    res = await client.post(
+        f"/api/v1/accounts/{account['id']}/transactions",
+        json=_transaction_payload(bill_id=other_bill["id"]),
+    )
+    assert res.status_code == 404
+
+
+async def test_transactions_scoped_to_account_owner(client: AsyncClient):
+    account = await _create_account(client)
+    await client.post(f"/api/v1/accounts/{account['id']}/transactions", json=_transaction_payload())
+
+    _login_as("auth0|someone-else")
+    res = await client.get(f"/api/v1/accounts/{account['id']}/transactions")
+    assert res.status_code == 404
+
+    res = await client.post(
+        f"/api/v1/accounts/{account['id']}/transactions", json=_transaction_payload()
+    )
+    assert res.status_code == 404

--- a/backend/tests/test_transactions_api.py
+++ b/backend/tests/test_transactions_api.py
@@ -49,6 +49,19 @@ async def test_create_and_list_transactions(client: AsyncClient):
     assert len(res.json()) == 1
 
 
+async def test_list_transactions_orders_newest_first(client: AsyncClient):
+    account = await _create_account(client)
+    for d in ("2024-01-01", "2024-03-01", "2024-02-01"):
+        await client.post(
+            f"/api/v1/accounts/{account['id']}/transactions",
+            json=_transaction_payload(date=d),
+        )
+
+    res = await client.get(f"/api/v1/accounts/{account['id']}/transactions")
+    dates = [t["date"] for t in res.json()]
+    assert dates == ["2024-03-01", "2024-02-01", "2024-01-01"]
+
+
 async def test_update_transaction(client: AsyncClient):
     account = await _create_account(client)
     transaction = (

--- a/backend/tests/test_transactions_api.py
+++ b/backend/tests/test_transactions_api.py
@@ -65,6 +65,35 @@ async def test_update_transaction(client: AsyncClient):
     assert res.json()["amount_cents"] == 500
 
 
+async def test_update_transaction_rejects_explicit_null_on_required_field(client: AsyncClient):
+    account = await _create_account(client)
+    transaction = (
+        await client.post(
+            f"/api/v1/accounts/{account['id']}/transactions", json=_transaction_payload()
+        )
+    ).json()
+
+    res = await client.patch(
+        f"/api/v1/accounts/{account['id']}/transactions/{transaction['id']}",
+        json={"amount_cents": None},
+    )
+    assert res.status_code == 422
+
+    res = await client.patch(
+        f"/api/v1/accounts/{account['id']}/transactions/{transaction['id']}",
+        json={"date": None},
+    )
+    assert res.status_code == 422
+
+    # Nullable fields (description, bill_id) may still be explicitly cleared.
+    res = await client.patch(
+        f"/api/v1/accounts/{account['id']}/transactions/{transaction['id']}",
+        json={"description": None},
+    )
+    assert res.status_code == 200
+    assert res.json()["description"] is None
+
+
 async def test_delete_transaction(client: AsyncClient):
     account = await _create_account(client)
     transaction = (

--- a/backend/tests/test_windfalls_api.py
+++ b/backend/tests/test_windfalls_api.py
@@ -64,6 +64,22 @@ async def test_update_windfall(client: AsyncClient):
     assert res.json()["amount_cents"] == 75000
 
 
+async def test_update_windfall_rejects_explicit_null_on_required_field(client: AsyncClient):
+    account = await _create_account(client)
+    windfall = (
+        await client.post(
+            f"/api/v1/accounts/{account['id']}/windfalls", json=_windfall_payload()
+        )
+    ).json()
+
+    for field in ("name", "amount_cents", "expected_date"):
+        res = await client.patch(
+            f"/api/v1/accounts/{account['id']}/windfalls/{windfall['id']}",
+            json={field: None},
+        )
+        assert res.status_code == 422
+
+
 async def test_delete_windfall(client: AsyncClient):
     account = await _create_account(client)
     windfall = (

--- a/backend/tests/test_windfalls_api.py
+++ b/backend/tests/test_windfalls_api.py
@@ -1,0 +1,93 @@
+import pytest
+from httpx import AsyncClient
+
+from src.core.auth import get_current_user
+from src.main import app
+from tests.conftest import auth_as
+
+
+def _login_as(sub: str) -> None:
+    app.dependency_overrides[get_current_user] = auth_as(sub)
+
+
+@pytest.fixture(autouse=True)
+def _default_user():
+    _login_as("auth0|owner")
+    yield
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+async def _create_account(client: AsyncClient) -> dict:
+    res = await client.post("/api/v1/accounts", json={"name": "Checking"})
+    return res.json()
+
+
+def _windfall_payload(**overrides) -> dict:
+    payload = {
+        "name": "Tax refund",
+        "amount_cents": 50000,
+        "expected_date": "2024-04-15",
+    }
+    payload.update(overrides)
+    return payload
+
+
+async def test_create_and_list_windfalls(client: AsyncClient):
+    account = await _create_account(client)
+
+    res = await client.post(
+        f"/api/v1/accounts/{account['id']}/windfalls", json=_windfall_payload()
+    )
+    assert res.status_code == 201
+    body = res.json()
+    assert body["name"] == "Tax refund"
+    assert body["amount_cents"] == 50000
+
+    res = await client.get(f"/api/v1/accounts/{account['id']}/windfalls")
+    assert res.status_code == 200
+    assert len(res.json()) == 1
+
+
+async def test_update_windfall(client: AsyncClient):
+    account = await _create_account(client)
+    windfall = (
+        await client.post(
+            f"/api/v1/accounts/{account['id']}/windfalls", json=_windfall_payload()
+        )
+    ).json()
+
+    res = await client.patch(
+        f"/api/v1/accounts/{account['id']}/windfalls/{windfall['id']}",
+        json={"amount_cents": 75000},
+    )
+    assert res.status_code == 200
+    assert res.json()["amount_cents"] == 75000
+
+
+async def test_delete_windfall(client: AsyncClient):
+    account = await _create_account(client)
+    windfall = (
+        await client.post(
+            f"/api/v1/accounts/{account['id']}/windfalls", json=_windfall_payload()
+        )
+    ).json()
+
+    res = await client.delete(f"/api/v1/accounts/{account['id']}/windfalls/{windfall['id']}")
+    assert res.status_code == 204
+
+    res = await client.get(f"/api/v1/accounts/{account['id']}/windfalls")
+    assert res.json() == []
+
+
+async def test_windfalls_scoped_to_account_owner(client: AsyncClient):
+    account = await _create_account(client)
+    await client.post(f"/api/v1/accounts/{account['id']}/windfalls", json=_windfall_payload())
+
+    _login_as("auth0|someone-else")
+    res = await client.get(f"/api/v1/accounts/{account['id']}/windfalls")
+    assert res.status_code == 404
+
+    res = await client.post(
+        f"/api/v1/accounts/{account['id']}/windfalls", json=_windfall_payload()
+    )
+    assert res.status_code == 404

--- a/backend/tests/test_windfalls_api.py
+++ b/backend/tests/test_windfalls_api.py
@@ -48,6 +48,19 @@ async def test_create_and_list_windfalls(client: AsyncClient):
     assert len(res.json()) == 1
 
 
+async def test_list_windfalls_orders_soonest_first(client: AsyncClient):
+    account = await _create_account(client)
+    for d in ("2024-06-01", "2024-04-15", "2024-05-01"):
+        await client.post(
+            f"/api/v1/accounts/{account['id']}/windfalls",
+            json=_windfall_payload(expected_date=d),
+        )
+
+    res = await client.get(f"/api/v1/accounts/{account['id']}/windfalls")
+    dates = [w["expected_date"] for w in res.json()]
+    assert dates == ["2024-04-15", "2024-05-01", "2024-06-01"]
+
+
 async def test_update_windfall(client: AsyncClient):
     account = await _create_account(client)
     windfall = (

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -151,7 +151,7 @@ per-PR preview branch) make manual Neon console clicks a recurring chore.
 
 ## Phase 0 — Foundations
 
-**Status**: code complete
+**Status**: code complete; one follow-up item below (0.6)
 
 - [x] 0.1 Finalize data model (turn the sketch above into real SQLAlchemy models + an ER
       diagram in this doc)
@@ -170,6 +170,19 @@ per-PR preview branch) make manual Neon console clicks a recurring chore.
       `PUBLIC_AUTH0_CLIENT_ID`/`PUBLIC_AUTH0_AUDIENCE` filled in `frontend/.env` (see
       `frontend/.env.example`), and the dev URL (`http://localhost:5173`) added as an
       Allowed Callback/Logout/Web Origin URL in the Auth0 SPA application settings.
+- [ ] 0.6 Local dev auth bypass: an opt-in flag (env var, off by default) that skips real
+      Auth0 token validation entirely and JIT-provisions a fixed dummy user, so
+      `docker compose up` can be exercised end-to-end (including by an AI coding
+      assistant in a sandboxed environment) without a real Auth0 login. Dummy identity
+      themed as an It's Always Sunny in Philadelphia character, with an email-shaped
+      display name - e.g. `charlie.kelly@paddys.bar` - close enough to a real Auth0
+      `sub`/`email` claim pair that `get_current_db_user`'s JIT-provisioning path
+      (`backend/src/api/deps.py`) needs no special-casing for it. Backend:
+      short-circuit `get_current_user` (`backend/src/core/auth.py`) when the bypass flag
+      is set, skipping the JWKS fetch/JWT decode entirely. Frontend: skip the Auth0 SPA
+      redirect (`frontend/src/lib/auth.ts`) the same way, so login is instant locally.
+      **Must never be reachable in prod** - gate behind an explicit env var checked at
+      startup, never a request header/query param a client could set.
 
 ## Phase 1 — Accounts & Bills CRUD
 
@@ -250,20 +263,45 @@ per-PR preview branch) make manual Neon console clicks a recurring chore.
 
 ## Phase 3 — Transactions & Windfalls
 
-**Status**: not started
+**Status**: code complete
 
-- [ ] 3.1 Backend: one-off `transactions` CRUD, folded into the forecast calculation
-      alongside recurring bills
-- [ ] 3.2 Frontend: add/manage one-off transactions UI
-- [ ] 3.3 Backend: `windfalls` CRUD (future one-time income), folded into forecast
-- [ ] 3.4 Frontend: windfall entry UI, forecast visualization highlighting windfall
-      impact on the running balance
+- [x] 3.1 Backend: one-off `transactions` CRUD (`backend/src/api/transactions.py`),
+      folded into the forecast calculation alongside recurring bills
+      (`backend/src/forecast/`). `Transaction.amount_cents` is **signed** (positive
+      credits, negative debits) — unlike `Bill` (always a positive expense) or
+      `Windfall` (always positive income), a one-off transaction is general-purpose.
+      `Cycle`/`get_forecast` gained a combined `net_cents` per cycle
+      (`transactions_total + windfalls_total - bills_total`); the tables already existed
+      from Phase 0's initial migration, so no new migration was needed.
+- [x] 3.2 Frontend: `/accounts/[id]/transactions` — list/create/delete, matching the
+      bills page's original (pre-1.5/1.6) depth.
+- [x] 3.3 Backend: `windfalls` CRUD (`backend/src/api/windfalls.py`), folded into
+      forecast the same way — always a positive credit.
+- [x] 3.4 Frontend: `/accounts/[id]/windfalls` entry UI; the forecast page's expanded
+      cycle rows now also list transaction and windfall line items alongside bills,
+      windfalls visually distinguished with a badge (the one thing in a forecast that's
+      unambiguously good news). Added a shared `AccountNav` component
+      (`frontend/src/lib/components/AccountNav.svelte`) across all four per-account pages
+      (Bills/Transactions/Windfalls/Forecast) — the old one-off "← Accounts"/"Forecast →"
+      links didn't scale past two sibling pages.
 
 ## Phase 4 — Multi-account dashboard & polish
 
 **Status**: not started
 
-- [ ] 4.1 Dashboard aggregating all of a user's accounts (combined + per-account views)
+- [ ] 4.1 Dashboard aggregating all of a user's accounts (combined + per-account views).
+      Per account, a "current cycle" snapshot card: the pay cycle containing today (date
+      range, bills due, running balance) at a glance, linking through to the full forecast
+      page for that account. Reuses the forecast engine (`backend/src/forecast/`) rather
+      than new logic - the open question is how to correctly identify "the cycle
+      containing today" for cycle types that don't self-anchor (weekly/biweekly/monthly
+      only snap to whatever `start_date` a request gives them, unlike semimonthly's fixed
+      10th/25th boundaries - see `engine.py`'s `_cycle_bounds`), starting from the
+      account's saved `forecast_start_date`/`forecast_cycle_type`
+      (`BankAccount.forecast_*`, persisted since Phase 2.3) and stepping forward/backward
+      to the cycle that actually contains today, rather than naively calling
+      `get_forecast(start_date=today, end_date=today, ...)` (which would anchor a new
+      cycle AT today instead of finding the in-progress one).
 - [ ] 4.2 UI/design pass — consistent Svelte component system, responsive layout. Still open:
       general responsive layout pass, plus whatever else turns up. Done so far:
       - [x] a real date-picker component (`frontend/src/lib/components/DatePicker.svelte`,
@@ -276,6 +314,23 @@ per-PR preview branch) make manual Neon console clicks a recurring chore.
         used in both the dropdown and the bills table
 - [ ] 4.3 Error handling, loading states, empty states throughout
 - [ ] 4.4 Test coverage: forecast engine (pytest), key frontend components
+- [ ] 4.5 In-app help: a glossary/definitions page explaining Tally-specific terms (Cycle
+      Type, Frequency, Windfall, the semimonthly 10th/25th convention, etc. — the concepts
+      this app introduces that aren't self-explanatory from the UI alone), plus contextual
+      tooltips on the fields that use this vocabulary (the bill form's Frequency select,
+      the forecast form's Cycle select, the windfall form) so users get the definition in
+      the moment instead of leaving the page to look it up. No tooltip component exists
+      yet (`frontend/src/lib/components/`) — needs a small reusable one, hover/focus
+      triggered and keyboard accessible.
+- [ ] 4.6 Logged-out homepage: replace the current placeholder root page
+      (`frontend/src/routes/+page.svelte`, currently just a couple of sentences before
+      redirecting authenticated users to `/accounts`) with real marketing content — what
+      Tally is, why to sign up — plus an interactive demo: a pre-selected sample list of
+      bills the visitor can add to (and remove from) and immediately see the effect on a
+      forecast, no login required. Needs a public, unauthenticated forecast endpoint that
+      reuses `backend/src/forecast/get_forecast` directly against demo data in the request
+      (no DB writes, no account, no auth) rather than reimplementing the engine in JS for
+      the demo — keeps the demo's math guaranteed identical to the real product's.
 
 ## Phase 5 — Production hardening (ongoing, lower priority)
 
@@ -364,3 +419,15 @@ session (or a fresh Claude Code instance) orient in under a minute.
   or just persisted somewhere this port doesn't have yet. 1.7 (recurrence-config UI) is
   still open and still blocks semimonthly/custom_days bills from being real (they show up
   as "unscheduled" in any forecast). Next: 1.7, or Phase 3 (transactions & windfalls).
+- 2026-07-12: Phase 3 (transactions & windfalls) shipped — both CRUD'd
+  (`backend/src/api/{transactions,windfalls}.py`) and folded into the forecast engine via
+  a new per-cycle `net_cents` (transactions signed, windfalls always positive, bills
+  always subtracted); new `/accounts/[id]/{transactions,windfalls}` pages, and a shared
+  `AccountNav` component across all four per-account pages now that there are four
+  siblings instead of two. Tables already existed from Phase 0, so no new migration.
+  Also logged four follow-up items to the roadmap this session: 0.6 (local dev Auth0
+  bypass, It's Always Sunny themed dummy user), 4.1's dashboard now specs a per-account
+  "current cycle" snapshot card, 4.5 (in-app glossary + field tooltips for
+  Tally-specific vocabulary), and 4.6 (a real logged-out homepage with an interactive,
+  no-login forecast demo reusing the real engine via a new public endpoint). Next: 1.7,
+  Phase 4, or any of the newly-logged follow-ups.

--- a/frontend/src/lib/api/transactions.ts
+++ b/frontend/src/lib/api/transactions.ts
@@ -1,0 +1,22 @@
+import { apiJson } from '$lib/api';
+import type { Transaction, TransactionInput } from '$lib/api/types';
+
+export function listTransactions(accountId: number): Promise<Transaction[]> {
+	return apiJson(`/api/v1/accounts/${accountId}/transactions`);
+}
+
+export function createTransaction(
+	accountId: number,
+	input: TransactionInput
+): Promise<Transaction> {
+	return apiJson(`/api/v1/accounts/${accountId}/transactions`, {
+		method: 'POST',
+		body: JSON.stringify(input)
+	});
+}
+
+export function deleteTransaction(accountId: number, transactionId: number): Promise<void> {
+	return apiJson(`/api/v1/accounts/${accountId}/transactions/${transactionId}`, {
+		method: 'DELETE'
+	});
+}

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -52,6 +52,40 @@ export interface BillInput {
 	enabled?: boolean;
 }
 
+export interface Transaction {
+	id: number;
+	account_id: number;
+	bill_id: number | null;
+	// Signed: positive credits the balance, negative debits it.
+	amount_cents: number;
+	date: string;
+	description: string | null;
+	created_at: string;
+}
+
+export interface TransactionInput {
+	amount_cents: number;
+	date: string;
+	description?: string | null;
+	bill_id?: number | null;
+}
+
+export interface Windfall {
+	id: number;
+	account_id: number;
+	name: string;
+	// Always positive - a windfall is income by definition.
+	amount_cents: number;
+	expected_date: string;
+	created_at: string;
+}
+
+export interface WindfallInput {
+	name: string;
+	amount_cents: number;
+	expected_date: string;
+}
+
 export interface ForecastRequest {
 	start_date: string;
 	end_date: string;
@@ -67,11 +101,27 @@ export interface ForecastBillLine {
 	due_date: string;
 }
 
+export interface ForecastTransactionLine {
+	transaction_id: number;
+	amount_cents: number;
+	date: string;
+	description: string | null;
+}
+
+export interface ForecastWindfallLine {
+	windfall_id: number;
+	name: string;
+	amount_cents: number;
+	expected_date: string;
+}
+
 export interface ForecastCycle {
 	start_date: string;
 	end_date: string;
 	bills: ForecastBillLine[];
-	cycle_sum_cents: number;
+	transactions: ForecastTransactionLine[];
+	windfalls: ForecastWindfallLine[];
+	net_cents: number;
 	running_balance_cents: number;
 }
 

--- a/frontend/src/lib/api/windfalls.ts
+++ b/frontend/src/lib/api/windfalls.ts
@@ -1,0 +1,19 @@
+import { apiJson } from '$lib/api';
+import type { Windfall, WindfallInput } from '$lib/api/types';
+
+export function listWindfalls(accountId: number): Promise<Windfall[]> {
+	return apiJson(`/api/v1/accounts/${accountId}/windfalls`);
+}
+
+export function createWindfall(accountId: number, input: WindfallInput): Promise<Windfall> {
+	return apiJson(`/api/v1/accounts/${accountId}/windfalls`, {
+		method: 'POST',
+		body: JSON.stringify(input)
+	});
+}
+
+export function deleteWindfall(accountId: number, windfallId: number): Promise<void> {
+	return apiJson(`/api/v1/accounts/${accountId}/windfalls/${windfallId}`, {
+		method: 'DELETE'
+	});
+}

--- a/frontend/src/lib/components/AccountNav.svelte
+++ b/frontend/src/lib/components/AccountNav.svelte
@@ -7,12 +7,12 @@
 		current: 'bills' | 'transactions' | 'windfalls' | 'forecast';
 	} = $props();
 
-	const links: { key: typeof current; label: string; href: string }[] = [
+	const links = $derived<{ key: typeof current; label: string; href: string }[]>([
 		{ key: 'bills', label: 'Bills', href: `/accounts/${accountId}` },
 		{ key: 'transactions', label: 'Transactions', href: `/accounts/${accountId}/transactions` },
 		{ key: 'windfalls', label: 'Windfalls', href: `/accounts/${accountId}/windfalls` },
 		{ key: 'forecast', label: 'Forecast', href: `/accounts/${accountId}/forecast` }
-	];
+	]);
 </script>
 
 <div class="flex items-center justify-between">

--- a/frontend/src/lib/components/AccountNav.svelte
+++ b/frontend/src/lib/components/AccountNav.svelte
@@ -17,7 +17,7 @@
 
 <div class="flex items-center justify-between">
 	<a class="text-sm text-primary underline" href="/accounts">&larr; Accounts</a>
-	<nav class="flex items-center gap-4">
+	<nav class="flex items-center gap-4" aria-label="Account">
 		{#each links as link (link.key)}
 			<a
 				href={link.href}

--- a/frontend/src/lib/components/AccountNav.svelte
+++ b/frontend/src/lib/components/AccountNav.svelte
@@ -21,6 +21,7 @@
 		{#each links as link (link.key)}
 			<a
 				href={link.href}
+				aria-current={link.key === current ? 'page' : undefined}
 				class="text-sm {link.key === current
 					? 'font-semibold text-primary'
 					: 'text-slate-600 hover:text-primary'}"

--- a/frontend/src/lib/components/AccountNav.svelte
+++ b/frontend/src/lib/components/AccountNav.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	let {
+		accountId,
+		current
+	}: {
+		accountId: number;
+		current: 'bills' | 'transactions' | 'windfalls' | 'forecast';
+	} = $props();
+
+	const links: { key: typeof current; label: string; href: string }[] = [
+		{ key: 'bills', label: 'Bills', href: `/accounts/${accountId}` },
+		{ key: 'transactions', label: 'Transactions', href: `/accounts/${accountId}/transactions` },
+		{ key: 'windfalls', label: 'Windfalls', href: `/accounts/${accountId}/windfalls` },
+		{ key: 'forecast', label: 'Forecast', href: `/accounts/${accountId}/forecast` }
+	];
+</script>
+
+<div class="flex items-center justify-between">
+	<a class="text-sm text-primary underline" href="/accounts">&larr; Accounts</a>
+	<nav class="flex items-center gap-4">
+		{#each links as link (link.key)}
+			<a
+				href={link.href}
+				class="text-sm {link.key === current
+					? 'font-semibold text-primary'
+					: 'text-slate-600 hover:text-primary'}"
+			>
+				{link.label}
+			</a>
+		{/each}
+	</nav>
+</div>

--- a/frontend/src/routes/(app)/accounts/[id]/+page.svelte
+++ b/frontend/src/routes/(app)/accounts/[id]/+page.svelte
@@ -3,6 +3,7 @@
 	import { getAccount, listAccounts } from '$lib/api/accounts';
 	import { createBill, deleteBill, listBills, updateBill } from '$lib/api/bills';
 	import type { BankAccount, Bill, RecurrenceType } from '$lib/api/types';
+	import AccountNav from '$lib/components/AccountNav.svelte';
 	import Badge from '$lib/components/Badge.svelte';
 	import Button from '$lib/components/Button.svelte';
 	import Card from '$lib/components/Card.svelte';
@@ -138,13 +139,10 @@
 	}
 </script>
 
-<a class="text-sm text-primary underline" href="/accounts">&larr; Accounts</a>
-<div class="mt-2 flex items-center justify-between">
-	<h1 class="text-2xl font-semibold text-text">
-		Bills{#if account} ({account.name}{#if account.institution} - {account.institution}{/if}){/if}
-	</h1>
-	<a class="text-sm text-primary underline" href="/accounts/{accountId}/forecast">Forecast &rarr;</a>
-</div>
+<AccountNav {accountId} current="bills" />
+<h1 class="mt-2 text-2xl font-semibold text-text">
+	Bills{#if account} ({account.name}{#if account.institution} - {account.institution}{/if}){/if}
+</h1>
 
 {#if error}
 	<p class="mt-4 rounded-card bg-red-50 px-4 py-2 text-sm text-red-700">{error}</p>

--- a/frontend/src/routes/(app)/accounts/[id]/forecast/+page.svelte
+++ b/frontend/src/routes/(app)/accounts/[id]/forecast/+page.svelte
@@ -202,7 +202,7 @@
 								<td class="px-4 py-2">{transaction.description ?? 'Transaction'}</td>
 								<td
 									class="px-4 py-2 text-right {transaction.amount_cents < 0
-										? ''
+										? 'text-red-700'
 										: 'text-emerald-700'}"
 								>
 									{formatAmount(transaction.amount_cents)}

--- a/frontend/src/routes/(app)/accounts/[id]/forecast/+page.svelte
+++ b/frontend/src/routes/(app)/accounts/[id]/forecast/+page.svelte
@@ -3,6 +3,7 @@
 	import { getAccount } from '$lib/api/accounts';
 	import { computeForecast } from '$lib/api/forecast';
 	import type { BankAccount, CycleType, ForecastResponse } from '$lib/api/types';
+	import AccountNav from '$lib/components/AccountNav.svelte';
 	import Button from '$lib/components/Button.svelte';
 	import Card from '$lib/components/Card.svelte';
 	import DatePicker from '$lib/components/DatePicker.svelte';
@@ -110,7 +111,7 @@
 	}
 </script>
 
-<a class="text-sm text-primary underline" href="/accounts/{accountId}">&larr; Bills</a>
+<AccountNav {accountId} current="forecast" />
 <h1 class="mt-2 text-2xl font-semibold text-text">
 	Forecast{#if account}
 		({account.name}{#if account.institution} - {account.institution}{/if}){/if}
@@ -167,7 +168,8 @@
 			</thead>
 			<tbody>
 				{#each forecast.cycles as cycle (cycle.start_date)}
-					{@const clickable = cycle.bills.length > 0}
+					{@const clickable =
+						cycle.bills.length > 0 || cycle.transactions.length > 0 || cycle.windfalls.length > 0}
 					<tr class="border-b border-slate-100 last:border-0 {rowClass(cycle.running_balance_cents)}">
 						{#if clickable}
 							<td class="p-0" colspan="3">
@@ -187,11 +189,40 @@
 						{/if}
 					</tr>
 					{#if expanded[cycle.start_date]}
-						{#each cycle.bills as bill (`${bill.bill_id}-${bill.due_date}`)}
+						{#each cycle.bills as bill (`bill-${bill.bill_id}-${bill.due_date}`)}
 							<tr class="border-b border-slate-100 text-sm text-slate-600 last:border-0">
 								<td class="px-4 py-2 pl-8">{bill.due_date}</td>
 								<td class="px-4 py-2">{bill.name}</td>
 								<td class="px-4 py-2 text-right">{formatAmount(bill.amount_cents)}</td>
+							</tr>
+						{/each}
+						{#each cycle.transactions as transaction (`transaction-${transaction.transaction_id}`)}
+							<tr class="border-b border-slate-100 text-sm text-slate-600 last:border-0">
+								<td class="px-4 py-2 pl-8">{transaction.date}</td>
+								<td class="px-4 py-2">{transaction.description ?? 'Transaction'}</td>
+								<td
+									class="px-4 py-2 text-right {transaction.amount_cents < 0
+										? ''
+										: 'text-emerald-700'}"
+								>
+									{formatAmount(transaction.amount_cents)}
+								</td>
+							</tr>
+						{/each}
+						{#each cycle.windfalls as windfall (`windfall-${windfall.windfall_id}`)}
+							<tr class="border-b border-slate-100 text-sm text-slate-600 last:border-0">
+								<td class="px-4 py-2 pl-8">{windfall.expected_date}</td>
+								<td class="px-4 py-2">
+									<span
+										class="inline-flex items-center rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-800"
+									>
+										Windfall
+									</span>
+									{windfall.name}
+								</td>
+								<td class="px-4 py-2 text-right text-emerald-700">
+									{formatAmount(windfall.amount_cents)}
+								</td>
 							</tr>
 						{/each}
 					{/if}

--- a/frontend/src/routes/(app)/accounts/[id]/transactions/+page.svelte
+++ b/frontend/src/routes/(app)/accounts/[id]/transactions/+page.svelte
@@ -43,7 +43,10 @@
 	async function handleCreate(event: SubmitEvent) {
 		event.preventDefault();
 		const amountCents = Math.round(Number(amount) * 100);
-		if (!date || Number.isNaN(amountCents)) return;
+		if (!date || Number.isNaN(amountCents)) {
+			error = 'Please choose a date.';
+			return;
+		}
 		creating = true;
 		try {
 			await createTransaction(accountId, {

--- a/frontend/src/routes/(app)/accounts/[id]/transactions/+page.svelte
+++ b/frontend/src/routes/(app)/accounts/[id]/transactions/+page.svelte
@@ -1,0 +1,140 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+	import { getAccount } from '$lib/api/accounts';
+	import { createTransaction, deleteTransaction, listTransactions } from '$lib/api/transactions';
+	import type { BankAccount, Transaction } from '$lib/api/types';
+	import AccountNav from '$lib/components/AccountNav.svelte';
+	import Button from '$lib/components/Button.svelte';
+	import Card from '$lib/components/Card.svelte';
+	import DatePicker from '$lib/components/DatePicker.svelte';
+	import Input from '$lib/components/Input.svelte';
+	import Table from '$lib/components/Table.svelte';
+	import { onMount } from 'svelte';
+
+	const accountId = $derived(Number($page.params.id));
+
+	let account = $state<BankAccount | null>(null);
+	let transactions = $state<Transaction[]>([]);
+	let loading = $state(true);
+	let error = $state<string | null>(null);
+
+	let amount = $state('');
+	let date = $state('');
+	let description = $state('');
+	let creating = $state(false);
+
+	async function load() {
+		loading = true;
+		error = null;
+		try {
+			[account, transactions] = await Promise.all([
+				getAccount(accountId),
+				listTransactions(accountId)
+			]);
+		} catch (err) {
+			error = err instanceof Error ? err.message : String(err);
+		} finally {
+			loading = false;
+		}
+	}
+
+	onMount(load);
+
+	async function handleCreate(event: SubmitEvent) {
+		event.preventDefault();
+		const amountCents = Math.round(Number(amount) * 100);
+		if (!date || Number.isNaN(amountCents)) return;
+		creating = true;
+		try {
+			await createTransaction(accountId, {
+				amount_cents: amountCents,
+				date,
+				description: description || null
+			});
+			amount = '';
+			date = '';
+			description = '';
+			await load();
+		} catch (err) {
+			error = err instanceof Error ? err.message : String(err);
+		} finally {
+			creating = false;
+		}
+	}
+
+	async function handleDelete(transactionId: number) {
+		try {
+			await deleteTransaction(accountId, transactionId);
+			await load();
+		} catch (err) {
+			error = err instanceof Error ? err.message : String(err);
+		}
+	}
+
+	function formatAmount(cents: number): string {
+		return (cents / 100).toLocaleString(undefined, { style: 'currency', currency: 'USD' });
+	}
+</script>
+
+<AccountNav {accountId} current="transactions" />
+<h1 class="mt-2 text-2xl font-semibold text-text">
+	Transactions{#if account}
+		({account.name}{#if account.institution} - {account.institution}{/if}){/if}
+</h1>
+
+{#if error}
+	<p class="mt-4 rounded-card bg-red-50 px-4 py-2 text-sm text-red-700">{error}</p>
+{/if}
+
+<Card>
+	<form class="flex flex-wrap items-end gap-4" onsubmit={handleCreate}>
+		<Input
+			label="Amount ($)"
+			type="number"
+			step="0.01"
+			bind:value={amount}
+			placeholder="-25.00"
+			required
+		/>
+		<DatePicker label="Date" bind:value={date} />
+		<Input label="Description" bind:value={description} placeholder="Optional" />
+		<Button type="submit" disabled={creating}>Add transaction</Button>
+	</form>
+</Card>
+
+<div class="mt-6">
+	{#if loading}
+		<p class="text-sm text-slate-500">Loading...</p>
+	{:else if transactions.length === 0}
+		<p class="text-sm text-slate-500">No transactions yet.</p>
+	{:else}
+		<Table>
+			<thead>
+				<tr class="border-b border-slate-200 text-xs uppercase text-slate-500">
+					<th class="px-4 py-2 font-medium">Date</th>
+					<th class="px-4 py-2 font-medium">Description</th>
+					<th class="px-4 py-2 text-right font-medium">Amount</th>
+					<th class="px-4 py-2"></th>
+				</tr>
+			</thead>
+			<tbody>
+				{#each transactions as transaction (transaction.id)}
+					<tr class="border-b border-slate-100 last:border-0">
+						<td class="px-4 py-2">{transaction.date}</td>
+						<td class="px-4 py-2 text-slate-600">{transaction.description ?? '—'}</td>
+						<td
+							class="px-4 py-2 text-right {transaction.amount_cents < 0
+								? 'text-red-700'
+								: 'text-emerald-700'}"
+						>
+							{formatAmount(transaction.amount_cents)}
+						</td>
+						<td class="px-4 py-2 text-right">
+							<Button variant="danger" onclick={() => handleDelete(transaction.id)}>Delete</Button>
+						</td>
+					</tr>
+				{/each}
+			</tbody>
+		</Table>
+	{/if}
+</div>

--- a/frontend/src/routes/(app)/accounts/[id]/transactions/+page.svelte
+++ b/frontend/src/routes/(app)/accounts/[id]/transactions/+page.svelte
@@ -44,7 +44,7 @@
 		event.preventDefault();
 		const amountCents = Math.round(Number(amount) * 100);
 		if (!date || Number.isNaN(amountCents)) {
-			error = 'Please choose a date.';
+			error = !date ? 'Please choose a date.' : 'Please enter a valid amount.';
 			return;
 		}
 		creating = true;

--- a/frontend/src/routes/(app)/accounts/[id]/windfalls/+page.svelte
+++ b/frontend/src/routes/(app)/accounts/[id]/windfalls/+page.svelte
@@ -1,0 +1,136 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+	import { getAccount } from '$lib/api/accounts';
+	import { createWindfall, deleteWindfall, listWindfalls } from '$lib/api/windfalls';
+	import type { BankAccount, Windfall } from '$lib/api/types';
+	import AccountNav from '$lib/components/AccountNav.svelte';
+	import Button from '$lib/components/Button.svelte';
+	import Card from '$lib/components/Card.svelte';
+	import DatePicker from '$lib/components/DatePicker.svelte';
+	import Input from '$lib/components/Input.svelte';
+	import Table from '$lib/components/Table.svelte';
+	import { onMount } from 'svelte';
+
+	const accountId = $derived(Number($page.params.id));
+
+	let account = $state<BankAccount | null>(null);
+	let windfalls = $state<Windfall[]>([]);
+	let loading = $state(true);
+	let error = $state<string | null>(null);
+
+	let name = $state('');
+	let amount = $state('');
+	let expectedDate = $state('');
+	let creating = $state(false);
+
+	async function load() {
+		loading = true;
+		error = null;
+		try {
+			[account, windfalls] = await Promise.all([
+				getAccount(accountId),
+				listWindfalls(accountId)
+			]);
+		} catch (err) {
+			error = err instanceof Error ? err.message : String(err);
+		} finally {
+			loading = false;
+		}
+	}
+
+	onMount(load);
+
+	async function handleCreate(event: SubmitEvent) {
+		event.preventDefault();
+		const amountCents = Math.round(Number(amount) * 100);
+		if (!name.trim() || !expectedDate || Number.isNaN(amountCents)) return;
+		creating = true;
+		try {
+			await createWindfall(accountId, {
+				name,
+				amount_cents: amountCents,
+				expected_date: expectedDate
+			});
+			name = '';
+			amount = '';
+			expectedDate = '';
+			await load();
+		} catch (err) {
+			error = err instanceof Error ? err.message : String(err);
+		} finally {
+			creating = false;
+		}
+	}
+
+	async function handleDelete(windfallId: number) {
+		try {
+			await deleteWindfall(accountId, windfallId);
+			await load();
+		} catch (err) {
+			error = err instanceof Error ? err.message : String(err);
+		}
+	}
+
+	function formatAmount(cents: number): string {
+		return (cents / 100).toLocaleString(undefined, { style: 'currency', currency: 'USD' });
+	}
+</script>
+
+<AccountNav {accountId} current="windfalls" />
+<h1 class="mt-2 text-2xl font-semibold text-text">
+	Windfalls{#if account}
+		({account.name}{#if account.institution} - {account.institution}{/if}){/if}
+</h1>
+
+{#if error}
+	<p class="mt-4 rounded-card bg-red-50 px-4 py-2 text-sm text-red-700">{error}</p>
+{/if}
+
+<Card>
+	<form class="flex flex-wrap items-end gap-4" onsubmit={handleCreate}>
+		<Input label="Name" bind:value={name} placeholder="Tax refund" required />
+		<Input
+			label="Amount ($)"
+			type="number"
+			step="0.01"
+			bind:value={amount}
+			placeholder="500.00"
+			required
+		/>
+		<DatePicker label="Expected date" bind:value={expectedDate} />
+		<Button type="submit" disabled={creating}>Add windfall</Button>
+	</form>
+</Card>
+
+<div class="mt-6">
+	{#if loading}
+		<p class="text-sm text-slate-500">Loading...</p>
+	{:else if windfalls.length === 0}
+		<p class="text-sm text-slate-500">No windfalls yet.</p>
+	{:else}
+		<Table>
+			<thead>
+				<tr class="border-b border-slate-200 text-xs uppercase text-slate-500">
+					<th class="px-4 py-2 font-medium">Expected date</th>
+					<th class="px-4 py-2 font-medium">Name</th>
+					<th class="px-4 py-2 text-right font-medium">Amount</th>
+					<th class="px-4 py-2"></th>
+				</tr>
+			</thead>
+			<tbody>
+				{#each windfalls as windfall (windfall.id)}
+					<tr class="border-b border-slate-100 last:border-0">
+						<td class="px-4 py-2">{windfall.expected_date}</td>
+						<td class="px-4 py-2">{windfall.name}</td>
+						<td class="px-4 py-2 text-right text-emerald-700">
+							{formatAmount(windfall.amount_cents)}
+						</td>
+						<td class="px-4 py-2 text-right">
+							<Button variant="danger" onclick={() => handleDelete(windfall.id)}>Delete</Button>
+						</td>
+					</tr>
+				{/each}
+			</tbody>
+		</Table>
+	{/if}
+</div>

--- a/frontend/src/routes/(app)/accounts/[id]/windfalls/+page.svelte
+++ b/frontend/src/routes/(app)/accounts/[id]/windfalls/+page.svelte
@@ -43,8 +43,12 @@
 	async function handleCreate(event: SubmitEvent) {
 		event.preventDefault();
 		const amountCents = Math.round(Number(amount) * 100);
-		if (!name.trim() || !expectedDate || Number.isNaN(amountCents)) {
-			error = !expectedDate ? 'Please choose an expected date.' : 'Please fill out all fields.';
+		if (!name.trim() || !expectedDate || Number.isNaN(amountCents) || amountCents <= 0) {
+			error = !expectedDate
+				? 'Please choose an expected date.'
+				: amountCents <= 0
+					? 'Amount must be greater than zero.'
+					: 'Please fill out all fields.';
 			return;
 		}
 		creating = true;

--- a/frontend/src/routes/(app)/accounts/[id]/windfalls/+page.svelte
+++ b/frontend/src/routes/(app)/accounts/[id]/windfalls/+page.svelte
@@ -43,7 +43,10 @@
 	async function handleCreate(event: SubmitEvent) {
 		event.preventDefault();
 		const amountCents = Math.round(Number(amount) * 100);
-		if (!name.trim() || !expectedDate || Number.isNaN(amountCents)) return;
+		if (!name.trim() || !expectedDate || Number.isNaN(amountCents)) {
+			error = !expectedDate ? 'Please choose an expected date.' : 'Please fill out all fields.';
+			return;
+		}
 		creating = true;
 		try {
 			await createWindfall(accountId, {


### PR DESCRIPTION
## Summary

Implements Phase 3 of the roadmap (transactions & windfalls) — one-off transactions and
future windfalls, both folded into the forecast engine alongside recurring bills. Closes
out roadmap items 3.1–3.4.

- **Engine** (`backend/src/forecast/`): `Cycle`/`get_forecast` now accept transactions
  and windfalls alongside bills, producing a combined per-cycle `net_cents`
  (`transactions_total + windfalls_total - bills_total`) rather than a second parallel
  total. `Transaction.amount_cents` is **signed** (positive credits, negative debits) —
  a one-off transaction is general-purpose, unlike `Bill` (always a positive expense) or
  `Windfall` (always positive income). New params are optional/defaulted, so Phase 2's
  golden-value tests are unaffected.
- **CRUD APIs**: `POST/GET/PATCH/DELETE .../accounts/{id}/{transactions,windfalls}`, same
  ownership-scoping pattern as bills. A transaction's optional `bill_id` is validated to
  belong to the same account. The `Transaction`/`Windfall` tables already existed from
  Phase 0's initial migration, so no new migration was needed this time.
- **Frontend**: new `/accounts/[id]/transactions` and `/accounts/[id]/windfalls` pages
  (list/create/delete); the forecast page's expanded cycle rows now also show
  transaction/windfall line items, windfalls marked with a badge. Added a shared
  `AccountNav` component across all four per-account pages, replacing the one-off
  "Accounts"/"Forecast" links that didn't scale past two siblings.
- **Docs**: checked off 3.1–3.4, and logged four new follow-up items caught during this
  session — a local-dev Auth0 bypass (0.6, It's Always Sunny themed dummy user), a
  per-account "current cycle" snapshot spec for the future dashboard (4.1), an in-app
  glossary + field tooltips for Tally-specific vocabulary (4.5), and a real logged-out
  homepage with an interactive no-login forecast demo (4.6).

Also fixed a genuine Python footgun along the way: `date: date | None = None` in a
Pydantic schema self-shadows — the default value binds the name `date` in the class body
*before* the `date | None` annotation is evaluated, so `date` resolves to `None` instead
of the `datetime.date` class. Confirmed `from __future__ import annotations` does **not**
fix this (Pydantic's forward-ref resolution still consults the class's own corrupted
namespace) — only avoiding the name collision does (`schemas/transaction.py` imports
`date` under an alias).

## Test plan

- [x] `cd backend && poetry run pytest` — 69 passed (new transaction/windfall CRUD tests,
      extended forecast engine/API tests for the new line-item types, full existing suite
      still green)
- [x] `cd frontend && yarn run check` — 0 errors
- [x] Migrations still apply cleanly (stamp base → upgrade head) — confirms no schema
      drift, as expected since the tables already existed
- [x] `docker compose` — backend/frontend rebuild and restart cleanly; headless-browser
      pass shows no console errors, new routes serve without error
- [ ] Manual click-through of the transactions/windfalls pages and the forecast page's
      new line items as a logged-in user — not done in this session (no login credentials
      available here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
