### PR TITLE
fix: serve index.html for SPA deep links instead of raw S3 AccessDenied

### DIFF
--- a/infra/modules/cloudfront/main.tf
+++ b/infra/modules/cloudfront/main.tf
@@ -71,6 +71,24 @@ resource "aws_cloudfront_distribution" "frontend" {
     origin_request_policy_id = data.aws_cloudfront_origin_request_policy.all_viewer_except_host_header.id
   }
 
+  # SPA deep-link support: the S3 origin is accessed via OAC against the REST
+  # API endpoint (not the S3 website endpoint), so a missing key like
+  # /dashboard comes back as a raw 403 AccessDenied (OAC-signed requests can't
+  # distinguish "missing" from "no permission") rather than a 404. Serve
+  # index.html with a 200 for both so SvelteKit's client-side router can
+  # handle the route itself.
+  custom_error_response {
+    error_code         = 403
+    response_code      = 200
+    response_page_path = "/index.html"
+  }
+
+  custom_error_response {
+    error_code         = 404
+    response_code      = 200
+    response_page_path = "/index.html"
+  }
+
   aliases     = var.aliases
   price_class = "PriceClass_100"
 


### PR DESCRIPTION
## Summary
- Refreshing (or directly loading) a client-side route like `/dashboard` returned a raw AWS `AccessDenied` XML response instead of the SvelteKit app.
- Root cause: the CloudFront origin hits S3's REST API endpoint via OAC, and OAC-signed requests against a private bucket return `403 AccessDenied` (not 404) for missing keys — `frontend_s3`'s `error_document` setting never applies here since that only works on S3's website endpoint, which OAC doesn't use.
- Added `custom_error_response` blocks to the CloudFront distribution mapping both 403 and 404 to `index.html` with a 200, so SvelteKit's client-side router can handle the route itself — the standard pattern for a CloudFront+S3+OAC SPA. No added cost.

## Test plan
- [x] `terraform fmt -check -recursive` clean
- [x] `terraform validate` passes
- [ ] `terraform-pr.yml` CI posts a plan showing only the two `custom_error_response` additions, no resource replacement
- [ ] After merge + apply, refresh `/dashboard` (and another deep link) against the live CloudFront domain and confirm the SPA loads instead of the AccessDenied XML

🤖 Generated with [Claude Code](https://claude.com/claude-code)
