### PR TITLE
feat: Phase 0/1 follow-ups - dev auth bypass, recurrence UI, CSV import/export, bill notes

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -6,3 +6,7 @@ DATABASE_URL_READWRITE=postgresql+asyncpg://tally:tally@localhost:5433/tally
 # Auth0 tenant settings (Phase 0.4) — fill in after creating the Auth0 tenant/API.
 AUTH0_DOMAIN=your-tenant.us.auth0.com
 AUTH0_AUDIENCE=https://api.tally.example.com
+
+# Local dev only — skips real Auth0 token validation and JIT-provisions a
+# fixed dummy user. NEVER set this to true in a deployed environment.
+DEV_AUTH_BYPASS=false

--- a/backend/alembic/versions/12aa348bb14f_add_notes_to_bills.py
+++ b/backend/alembic/versions/12aa348bb14f_add_notes_to_bills.py
@@ -1,0 +1,28 @@
+"""add notes to bills
+
+Revision ID: 12aa348bb14f
+Revises: e6a7f75ee398
+Create Date: 2026-07-12 13:02:59.853557
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '12aa348bb14f'
+down_revision: Union[str, Sequence[str], None] = 'e6a7f75ee398'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column('bills', sa.Column('notes', sa.String(length=1000), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('bills', 'notes')

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -1003,6 +1003,17 @@ pycryptodome = ["pycryptodome (>=3.3.1,<4.0.0)"]
 test = ["pytest", "pytest-cov"]
 
 [[package]]
+name = "python-multipart"
+version = "0.0.32"
+description = "A streaming multipart parser for Python"
+optional = false
+python-versions = ">=3.10"
+files = [
+    {file = "python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23"},
+    {file = "python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e"},
+]
+
+[[package]]
 name = "rsa"
 version = "4.9.1"
 description = "Pure-Python RSA implementation"
@@ -1197,4 +1208,4 @@ standard = ["colorama (>=0.4)", "httptools (>=0.5.0)", "python-dotenv (>=0.13)",
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.13"
-content-hash = "d4146b89a8cfaaf0e3b92d82dcb056910961badb101869fc8cf9ed48b31b8e0a"
+content-hash = "1a425b832a902934fe44a2930c3fc3df932f17db59a5f04a5e8bc72a4ef04ba2"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -15,6 +15,7 @@ sqlalchemy = {version = ">=2.0", extras = ["asyncio"]}
 asyncpg = "^0.31.0"
 python-jose = {extras = ["cryptography"], version = "^3.5.0"}
 pydantic-settings = "^2.14.2"
+python-multipart = "^0.0.32"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0.0"

--- a/backend/src/api/bills.py
+++ b/backend/src/api/bills.py
@@ -6,10 +6,17 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.api.deps import get_bank_account_or_404, get_current_db_user, get_owned_bank_account
 from src.bills_csv import bills_to_csv, parse_csv_rows
 from src.core.database import get_db
-from src.models import BankAccount, Bill, User
+from src.forecast.bill import validate_recurrence_config
+from src.models import BankAccount, Bill, RecurrenceType, User
 from src.schemas.bill import BillCreate, BillRead, BillUpdate
 
 router = APIRouter(prefix="/api/v1/accounts/{account_id}/bills", tags=["bills"])
+
+
+def _validate_or_422(recurrence_type: RecurrenceType, recurrence_config: dict) -> None:
+    reason = validate_recurrence_config(recurrence_type, recurrence_config)
+    if reason:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=reason)
 
 
 async def _get_owned_bill(
@@ -41,6 +48,7 @@ async def create_bill(
     db: AsyncSession = Depends(get_db),
     account: BankAccount = Depends(get_owned_bank_account),
 ) -> Bill:
+    _validate_or_422(payload.recurrence_type, payload.recurrence_config)
     bill = Bill(account_id=account.id, **payload.model_dump())
     db.add(bill)
     await db.commit()
@@ -78,10 +86,11 @@ async def import_bills(
 
     bills = [Bill(account_id=account.id, **payload.model_dump()) for payload in parsed_bills]
     db.add_all(bills)
+    await db.flush()
+    ids = [bill.id for bill in bills]
     await db.commit()
-    for bill in bills:
-        await db.refresh(bill)
-    return bills
+    result = await db.execute(select(Bill).where(Bill.id.in_(ids)).order_by(Bill.id))
+    return list(result.scalars().all())
 
 
 @router.patch("/{bill_id}", response_model=BillRead)
@@ -98,6 +107,13 @@ async def update_bill(
         # scoped to (get_owned_bank_account only validated the *current*
         # account_id from the URL, not the new one in the body).
         await get_bank_account_or_404(update_data["account_id"], db, current_user)
+    # Validate the *resulting* combination, not just the patch fields alone -
+    # a PATCH that only touches amount_cents must still be checked against
+    # whatever recurrence_type/recurrence_config the bill will end up with.
+    _validate_or_422(
+        update_data.get("recurrence_type", bill.recurrence_type),
+        update_data.get("recurrence_config", bill.recurrence_config),
+    )
     for field, value in update_data.items():
         setattr(bill, field, value)
     await db.commit()

--- a/backend/src/api/bills.py
+++ b/backend/src/api/bills.py
@@ -1,8 +1,10 @@
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, status
+from fastapi.responses import Response
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.api.deps import get_bank_account_or_404, get_current_db_user, get_owned_bank_account
+from src.bills_csv import bills_to_csv, parse_csv_rows
 from src.core.database import get_db
 from src.models import BankAccount, Bill, User
 from src.schemas.bill import BillCreate, BillRead, BillUpdate
@@ -44,6 +46,42 @@ async def create_bill(
     await db.commit()
     await db.refresh(bill)
     return bill
+
+
+@router.get("/export")
+async def export_bills(
+    db: AsyncSession = Depends(get_db),
+    account: BankAccount = Depends(get_owned_bank_account),
+) -> Response:
+    result = await db.execute(select(Bill).where(Bill.account_id == account.id))
+    csv_text = bills_to_csv(list(result.scalars().all()))
+    return Response(
+        content=csv_text,
+        media_type="text/csv",
+        headers={"Content-Disposition": f'attachment; filename="bills-{account.id}.csv"'},
+    )
+
+
+@router.post("/import", response_model=list[BillRead], status_code=status.HTTP_201_CREATED)
+async def import_bills(
+    file: UploadFile,
+    db: AsyncSession = Depends(get_db),
+    account: BankAccount = Depends(get_owned_bank_account),
+) -> list[Bill]:
+    csv_text = (await file.read()).decode("utf-8-sig")  # -sig strips an Excel-added BOM
+    parsed_bills, errors = parse_csv_rows(csv_text)
+    if errors:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={"errors": [{"row": e.row, "message": e.message} for e in errors]},
+        )
+
+    bills = [Bill(account_id=account.id, **payload.model_dump()) for payload in parsed_bills]
+    db.add_all(bills)
+    await db.commit()
+    for bill in bills:
+        await db.refresh(bill)
+    return bills
 
 
 @router.patch("/{bill_id}", response_model=BillRead)

--- a/backend/src/bills_csv.py
+++ b/backend/src/bills_csv.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import csv
+import io
+from dataclasses import dataclass
+from datetime import date
+
+from pydantic import ValidationError
+
+from src.models.bill import RecurrenceType
+from src.schemas.bill import BillCreate
+
+CSV_COLUMNS = [
+    "name",
+    "amount",
+    "recurrence_type",
+    "semimonthly_days",
+    "custom_interval_days",
+    "start_date",
+    "end_date",
+    "enabled",
+    "notes",
+]
+
+
+@dataclass
+class RowError:
+    row: int  # 1-indexed, counting the header as row 1 (so row 2 is the first data row)
+    message: str
+
+
+def bill_to_csv_row(bill) -> dict:
+    """A Bill ORM instance -> a human-readable CSV row (dollars, not cents;
+    semimonthly/custom_days config flattened into their own columns instead
+    of raw JSON, since spreadsheet users shouldn't need to hand-edit JSON)."""
+    semimonthly_days = ""
+    custom_interval_days = ""
+    if bill.recurrence_type == RecurrenceType.SEMIMONTHLY:
+        semimonthly_days = ",".join(str(d) for d in bill.recurrence_config.get("days", []))
+    elif bill.recurrence_type == RecurrenceType.CUSTOM_DAYS:
+        interval = bill.recurrence_config.get("interval_days")
+        custom_interval_days = str(interval) if interval is not None else ""
+
+    return {
+        "name": bill.name,
+        "amount": f"{bill.amount_cents / 100:.2f}",
+        "recurrence_type": bill.recurrence_type.value,
+        "semimonthly_days": semimonthly_days,
+        "custom_interval_days": custom_interval_days,
+        "start_date": bill.start_date.isoformat(),
+        "end_date": bill.end_date.isoformat() if bill.end_date else "",
+        "enabled": "true" if bill.enabled else "false",
+        "notes": bill.notes or "",
+    }
+
+
+def bills_to_csv(bills: list) -> str:
+    buffer = io.StringIO()
+    writer = csv.DictWriter(buffer, fieldnames=CSV_COLUMNS)
+    writer.writeheader()
+    for bill in bills:
+        writer.writerow(bill_to_csv_row(bill))
+    return buffer.getvalue()
+
+
+def _parse_amount_cents(raw: str) -> int:
+    return round(float(raw) * 100)
+
+
+def _field(row: dict, key: str) -> str:
+    # csv.DictReader sets missing trailing fields to None (restval), not an
+    # absent key - row.get(key, "") only covers a truly absent key, so a
+    # short row would otherwise hit `.strip()` on None and raise
+    # AttributeError instead of a clean per-row ValueError.
+    return (row.get(key) or "").strip()
+
+
+def _parse_recurrence_config(row: dict) -> dict:
+    recurrence_type = _field(row, "recurrence_type")
+    if recurrence_type == RecurrenceType.SEMIMONTHLY.value:
+        days_raw = _field(row, "semimonthly_days")
+        if not days_raw:
+            raise ValueError("semimonthly bills need semimonthly_days, e.g. \"10,25\"")
+        days = [int(d.strip()) for d in days_raw.split(",") if d.strip()]
+        if not days or not all(1 <= d <= 31 for d in days):
+            raise ValueError("semimonthly_days must be integers 1-31, e.g. \"10,25\"")
+        return {"days": days}
+    if recurrence_type == RecurrenceType.CUSTOM_DAYS.value:
+        interval_raw = _field(row, "custom_interval_days")
+        if not interval_raw:
+            raise ValueError("custom_days bills need custom_interval_days")
+        interval = int(interval_raw)
+        if interval <= 0:
+            raise ValueError("custom_interval_days must be a positive integer")
+        return {"interval_days": interval}
+    return {}
+
+
+def _parse_row(row: dict) -> BillCreate:
+    name = _field(row, "name")
+    if not name:
+        raise ValueError("name is required")
+
+    amount_raw = _field(row, "amount")
+    if not amount_raw:
+        raise ValueError("amount is required")
+    amount_cents = _parse_amount_cents(amount_raw)
+
+    recurrence_type_raw = _field(row, "recurrence_type")
+    try:
+        recurrence_type = RecurrenceType(recurrence_type_raw)
+    except ValueError as exc:
+        valid = ", ".join(t.value for t in RecurrenceType)
+        raise ValueError(f"recurrence_type must be one of: {valid}") from exc
+
+    recurrence_config = _parse_recurrence_config(row)
+
+    start_date_raw = _field(row, "start_date")
+    if not start_date_raw:
+        raise ValueError("start_date is required")
+    start_date = date.fromisoformat(start_date_raw)
+
+    end_date_raw = _field(row, "end_date")
+    end_date = date.fromisoformat(end_date_raw) if end_date_raw else None
+
+    enabled_raw = _field(row, "enabled").lower()
+    enabled = enabled_raw not in ("false", "0")
+
+    notes = _field(row, "notes") or None
+
+    return BillCreate(
+        name=name,
+        amount_cents=amount_cents,
+        recurrence_type=recurrence_type,
+        recurrence_config=recurrence_config,
+        start_date=start_date,
+        end_date=end_date,
+        enabled=enabled,
+        notes=notes,
+    )
+
+
+def parse_csv_rows(csv_text: str) -> tuple[list[BillCreate], list[RowError]]:
+    """All-or-nothing: every row is validated before any is returned as
+    importable. If `errors` is non-empty, `bills` should not be inserted."""
+    reader = csv.DictReader(io.StringIO(csv_text))
+    bills: list[BillCreate] = []
+    errors: list[RowError] = []
+
+    for row_number, row in enumerate(reader, start=2):  # row 1 is the header
+        try:
+            bills.append(_parse_row(row))
+        except (ValueError, TypeError, ValidationError) as exc:
+            errors.append(RowError(row=row_number, message=str(exc)))
+
+    return bills, errors

--- a/backend/src/bills_csv.py
+++ b/backend/src/bills_csv.py
@@ -7,7 +7,8 @@ from datetime import date
 
 from pydantic import ValidationError
 
-from src.models.bill import RecurrenceType
+from src.forecast.bill import validate_recurrence_config
+from src.models.bill import Bill, RecurrenceType
 from src.schemas.bill import BillCreate
 
 CSV_COLUMNS = [
@@ -29,7 +30,7 @@ class RowError:
     message: str
 
 
-def bill_to_csv_row(bill) -> dict:
+def bill_to_csv_row(bill: Bill) -> dict:
     """A Bill ORM instance -> a human-readable CSV row (dollars, not cents;
     semimonthly/custom_days config flattened into their own columns instead
     of raw JSON, since spreadsheet users shouldn't need to hand-edit JSON)."""
@@ -75,25 +76,31 @@ def _field(row: dict, key: str) -> str:
     return (row.get(key) or "").strip()
 
 
-def _parse_recurrence_config(row: dict) -> dict:
-    recurrence_type = _field(row, "recurrence_type")
-    if recurrence_type == RecurrenceType.SEMIMONTHLY.value:
+def _parse_recurrence_config(row: dict, recurrence_type: RecurrenceType) -> dict:
+    # Only builds the dict from the CSV's flattened columns - validate_recurrence_config
+    # (backend/src/forecast/bill.py, the single source of truth for these shapes) is what
+    # actually checks it, so this and the JSON create/update API path can't drift apart.
+    if recurrence_type == RecurrenceType.SEMIMONTHLY:
         days_raw = _field(row, "semimonthly_days")
-        if not days_raw:
-            raise ValueError("semimonthly bills need semimonthly_days, e.g. \"10,25\"")
-        days = [int(d.strip()) for d in days_raw.split(",") if d.strip()]
-        if not days or not all(1 <= d <= 31 for d in days):
-            raise ValueError("semimonthly_days must be integers 1-31, e.g. \"10,25\"")
-        return {"days": days}
-    if recurrence_type == RecurrenceType.CUSTOM_DAYS.value:
+        try:
+            days = [int(d.strip()) for d in days_raw.split(",") if d.strip()]
+        except ValueError as exc:
+            raise ValueError('semimonthly_days must be integers, e.g. "10,25"') from exc
+        recurrence_config: dict = {"days": days}
+    elif recurrence_type == RecurrenceType.CUSTOM_DAYS:
         interval_raw = _field(row, "custom_interval_days")
-        if not interval_raw:
-            raise ValueError("custom_days bills need custom_interval_days")
-        interval = int(interval_raw)
-        if interval <= 0:
-            raise ValueError("custom_interval_days must be a positive integer")
-        return {"interval_days": interval}
-    return {}
+        try:
+            interval = int(interval_raw) if interval_raw else None
+        except ValueError as exc:
+            raise ValueError("custom_interval_days must be an integer") from exc
+        recurrence_config = {"interval_days": interval} if interval is not None else {}
+    else:
+        recurrence_config = {}
+
+    reason = validate_recurrence_config(recurrence_type, recurrence_config)
+    if reason:
+        raise ValueError(reason)
+    return recurrence_config
 
 
 def _parse_row(row: dict) -> BillCreate:
@@ -113,7 +120,7 @@ def _parse_row(row: dict) -> BillCreate:
         valid = ", ".join(t.value for t in RecurrenceType)
         raise ValueError(f"recurrence_type must be one of: {valid}") from exc
 
-    recurrence_config = _parse_recurrence_config(row)
+    recurrence_config = _parse_recurrence_config(row, recurrence_type)
 
     start_date_raw = _field(row, "start_date")
     if not start_date_raw:

--- a/backend/src/core/auth.py
+++ b/backend/src/core/auth.py
@@ -58,6 +58,12 @@ def _fetch_jwks_or_503(force_refresh: bool = False) -> dict:
 def get_current_user(
     credentials: HTTPAuthorizationCredentials | None = Depends(security),
 ) -> dict:
+    if settings.dev_auth_bypass:
+        # Local dev only (see Settings.dev_auth_bypass) - skips JWKS/jose
+        # entirely and returns a fixed identity, JIT-provisioned the same way
+        # a real Auth0 user would be (get_current_db_user only relies on
+        # `sub`/`email`, both present here).
+        return {"sub": "auth0|charlie_kelly_dev", "email": "charlie.kelly@paddys.bar"}
     if credentials is None:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated"

--- a/backend/src/core/config.py
+++ b/backend/src/core/config.py
@@ -15,6 +15,12 @@ class Settings(BaseSettings):
     auth0_domain: str = ""
     auth0_audience: str = ""
 
+    # Skips real Auth0 token validation entirely and JIT-provisions a fixed
+    # dummy user (see get_current_user) - lets `docker compose up` be
+    # exercised end-to-end without a real Auth0 login. Off by default; must
+    # never be set in a deployed environment (nothing in infra/ sets this).
+    dev_auth_bypass: bool = False
+
     @field_validator("database_url_readwrite")
     @classmethod
     def _normalize_for_asyncpg(cls, value: str) -> str:

--- a/backend/src/forecast/bill.py
+++ b/backend/src/forecast/bill.py
@@ -40,19 +40,24 @@ def _clamp_day(year: int, month: int, day: int) -> int:
     return min(day, _last_day_of_month(year, month))
 
 
-def validate_recurrence_config(bill: ForecastBill) -> str | None:
-    """Returns a human-readable reason if `bill.recurrence_config` is missing data
-    required for its recurrence_type, else None."""
-    if bill.recurrence_type == RecurrenceType.SEMIMONTHLY:
-        days = bill.recurrence_config.get("days")
+def validate_recurrence_config(recurrence_type: RecurrenceType, recurrence_config: dict) -> str | None:
+    """Returns a human-readable reason if `recurrence_config` is missing data
+    required for `recurrence_type`, else None.
+
+    The single source of truth for this shape - callers outside the forecast
+    engine (bill create/update, CSV import) should call this directly rather
+    than re-deriving the same 1-31/positive-int rules.
+    """
+    if recurrence_type == RecurrenceType.SEMIMONTHLY:
+        days = recurrence_config.get("days")
         if (
             not isinstance(days, list)
             or not days
             or not all(isinstance(d, int) and 1 <= d <= 31 for d in days)
         ):
             return "semimonthly bills need recurrence_config.days as integers 1-31, e.g. [10, 25]"
-    if bill.recurrence_type == RecurrenceType.CUSTOM_DAYS:
-        interval = bill.recurrence_config.get("interval_days")
+    if recurrence_type == RecurrenceType.CUSTOM_DAYS:
+        interval = recurrence_config.get("interval_days")
         if not isinstance(interval, int) or interval <= 0:
             return "custom_days bills need recurrence_config.interval_days"
     return None
@@ -128,7 +133,7 @@ def occurrences_in_range(bill: ForecastBill, cycle_start: date, cycle_end: date)
     that's absent - callers iterating many bills should pre-filter with
     validate_recurrence_config instead of catching this per-call.
     """
-    reason = validate_recurrence_config(bill)
+    reason = validate_recurrence_config(bill.recurrence_type, bill.recurrence_config)
     if reason:
         raise MissingRecurrenceConfig(reason)
 

--- a/backend/src/forecast/engine.py
+++ b/backend/src/forecast/engine.py
@@ -141,7 +141,7 @@ def get_forecast(
     schedulable: list[ForecastBill] = []
     unscheduled: list[UnscheduledBill] = []
     for bill in bills:
-        reason = validate_recurrence_config(bill)
+        reason = validate_recurrence_config(bill.recurrence_type, bill.recurrence_config)
         if reason:
             unscheduled.append(UnscheduledBill(bill_id=bill.id, name=bill.name, reason=reason))
         else:

--- a/backend/src/models/bill.py
+++ b/backend/src/models/bill.py
@@ -43,6 +43,7 @@ class Bill(Base):
     start_date: Mapped[date] = mapped_column(Date)
     end_date: Mapped[date | None] = mapped_column(Date)
     enabled: Mapped[bool] = mapped_column(Boolean, default=True, server_default=true())
+    notes: Mapped[str | None] = mapped_column(String(1000))
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )

--- a/backend/src/schemas/bill.py
+++ b/backend/src/schemas/bill.py
@@ -13,6 +13,7 @@ class BillCreate(BaseModel):
     start_date: date
     end_date: date | None = None
     enabled: bool = True
+    notes: str | None = None
 
 
 class BillUpdate(BaseModel):
@@ -24,6 +25,7 @@ class BillUpdate(BaseModel):
     end_date: date | None = None
     enabled: bool | None = None
     account_id: int | None = None
+    notes: str | None = None
 
 
 class BillRead(BaseModel):
@@ -38,5 +40,6 @@ class BillRead(BaseModel):
     start_date: date
     end_date: date | None
     enabled: bool
+    notes: str | None
     created_at: datetime
     updated_at: datetime

--- a/backend/src/schemas/bill.py
+++ b/backend/src/schemas/bill.py
@@ -1,8 +1,12 @@
 from datetime import date, datetime
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from src.models.bill import RecurrenceType
+
+# Matches Bill.notes' String(1000) column - keeps an over-long note a clean
+# 422 at the schema layer instead of an unhandled DB error at commit time.
+_NOTES_MAX_LENGTH = 1000
 
 
 class BillCreate(BaseModel):
@@ -13,7 +17,7 @@ class BillCreate(BaseModel):
     start_date: date
     end_date: date | None = None
     enabled: bool = True
-    notes: str | None = None
+    notes: str | None = Field(default=None, max_length=_NOTES_MAX_LENGTH)
 
 
 class BillUpdate(BaseModel):
@@ -25,7 +29,7 @@ class BillUpdate(BaseModel):
     end_date: date | None = None
     enabled: bool | None = None
     account_id: int | None = None
-    notes: str | None = None
+    notes: str | None = Field(default=None, max_length=_NOTES_MAX_LENGTH)
 
 
 class BillRead(BaseModel):

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -47,6 +47,15 @@ def _make_token(private_pem: bytes, **claim_overrides) -> str:
     return jwt.encode(claims, private_pem, algorithm="RS256")
 
 
+def test_get_current_user_bypasses_validation_when_dev_auth_bypass_is_set(monkeypatch):
+    monkeypatch.setattr(settings, "dev_auth_bypass", True)
+
+    payload = auth.get_current_user(None)
+
+    assert payload["sub"] == "auth0|charlie_kelly_dev"
+    assert payload["email"] == "charlie.kelly@paddys.bar"
+
+
 def test_get_current_user_rejects_missing_credentials_with_401():
     # HTTPBearer(auto_error=False) passes None here when the Authorization
     # header is absent - get_current_user must handle that itself rather than

--- a/backend/tests/test_bills_api.py
+++ b/backend/tests/test_bills_api.py
@@ -121,3 +121,87 @@ async def test_bills_scoped_to_account_owner(client: AsyncClient):
 
     res = await client.post(f"/api/v1/accounts/{account['id']}/bills", json=_bill_payload())
     assert res.status_code == 404
+
+
+async def test_export_bills_returns_csv(client: AsyncClient):
+    account = await _create_account(client)
+    await client.post(f"/api/v1/accounts/{account['id']}/bills", json=_bill_payload())
+
+    res = await client.get(f"/api/v1/accounts/{account['id']}/bills/export")
+    assert res.status_code == 200
+    assert res.headers["content-type"].startswith("text/csv")
+    assert "attachment" in res.headers["content-disposition"]
+    lines = res.text.strip().splitlines()
+    assert len(lines) == 2  # header + one bill
+    assert "Rent" in lines[1]
+    assert "1500.00" in lines[1]
+
+
+async def test_export_bills_scoped_to_account_owner(client: AsyncClient):
+    account = await _create_account(client)
+    await client.post(f"/api/v1/accounts/{account['id']}/bills", json=_bill_payload())
+
+    _login_as("auth0|someone-else")
+    res = await client.get(f"/api/v1/accounts/{account['id']}/bills/export")
+    assert res.status_code == 404
+
+
+async def test_import_bills_creates_all_rows(client: AsyncClient):
+    account = await _create_account(client)
+    csv_text = (
+        "name,amount,recurrence_type,semimonthly_days,custom_interval_days,"
+        "start_date,end_date,enabled,notes\n"
+        "Rent,1500.00,monthly,,,2026-01-01,,true,\n"
+        "Paycheck buffer,50.00,semimonthly,\"10,25\",,2026-01-01,,true,imported\n"
+    )
+    res = await client.post(
+        f"/api/v1/accounts/{account['id']}/bills/import",
+        files={"file": ("bills.csv", csv_text, "text/csv")},
+    )
+    assert res.status_code == 201
+    body = res.json()
+    assert len(body) == 2
+    assert {b["name"] for b in body} == {"Rent", "Paycheck buffer"}
+    semimonthly = next(b for b in body if b["name"] == "Paycheck buffer")
+    assert semimonthly["recurrence_config"] == {"days": [10, 25]}
+    assert semimonthly["notes"] == "imported"
+
+    res = await client.get(f"/api/v1/accounts/{account['id']}/bills")
+    assert len(res.json()) == 2
+
+
+async def test_import_bills_is_all_or_nothing_on_a_bad_row(client: AsyncClient):
+    account = await _create_account(client)
+    csv_text = (
+        "name,amount,recurrence_type,semimonthly_days,custom_interval_days,"
+        "start_date,end_date,enabled,notes\n"
+        "Rent,1500.00,monthly,,,2026-01-01,,true,\n"
+        ",50.00,monthly,,,2026-01-01,,true,\n"
+    )
+    res = await client.post(
+        f"/api/v1/accounts/{account['id']}/bills/import",
+        files={"file": ("bills.csv", csv_text, "text/csv")},
+    )
+    assert res.status_code == 422
+    errors = res.json()["detail"]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["row"] == 3
+
+    res = await client.get(f"/api/v1/accounts/{account['id']}/bills")
+    assert res.json() == []
+
+
+async def test_import_bills_scoped_to_account_owner(client: AsyncClient):
+    account = await _create_account(client)
+    csv_text = (
+        "name,amount,recurrence_type,semimonthly_days,custom_interval_days,"
+        "start_date,end_date,enabled,notes\n"
+        "Rent,1500.00,monthly,,,2026-01-01,,true,\n"
+    )
+
+    _login_as("auth0|someone-else")
+    res = await client.post(
+        f"/api/v1/accounts/{account['id']}/bills/import",
+        files={"file": ("bills.csv", csv_text, "text/csv")},
+    )
+    assert res.status_code == 404

--- a/backend/tests/test_bills_api.py
+++ b/backend/tests/test_bills_api.py
@@ -48,6 +48,64 @@ async def test_create_and_list_bills(client: AsyncClient):
     assert len(res.json()) == 1
 
 
+async def test_create_bill_rejects_notes_over_max_length(client: AsyncClient):
+    account = await _create_account(client)
+
+    res = await client.post(
+        f"/api/v1/accounts/{account['id']}/bills",
+        json=_bill_payload(notes="x" * 1001),
+    )
+    assert res.status_code == 422
+
+
+async def test_create_bill_rejects_invalid_recurrence_config(client: AsyncClient):
+    account = await _create_account(client)
+
+    res = await client.post(
+        f"/api/v1/accounts/{account['id']}/bills",
+        json=_bill_payload(recurrence_type="custom_days", recurrence_config={}),
+    )
+    assert res.status_code == 422
+    assert "interval_days" in res.json()["detail"]
+
+    res = await client.get(f"/api/v1/accounts/{account['id']}/bills")
+    assert res.json() == []
+
+
+async def test_update_bill_rejects_invalid_recurrence_config(client: AsyncClient):
+    account = await _create_account(client)
+    bill = (
+        await client.post(f"/api/v1/accounts/{account['id']}/bills", json=_bill_payload())
+    ).json()
+
+    res = await client.patch(
+        f"/api/v1/accounts/{account['id']}/bills/{bill['id']}",
+        json={"recurrence_type": "semimonthly"},
+    )
+    assert res.status_code == 422
+    assert "days" in res.json()["detail"]
+
+
+async def test_update_bill_unrelated_field_keeps_existing_valid_recurrence_config(
+    client: AsyncClient,
+):
+    account = await _create_account(client)
+    bill = (
+        await client.post(
+            f"/api/v1/accounts/{account['id']}/bills",
+            json=_bill_payload(recurrence_type="semimonthly", recurrence_config={"days": [10, 25]}),
+        )
+    ).json()
+
+    res = await client.patch(
+        f"/api/v1/accounts/{account['id']}/bills/{bill['id']}",
+        json={"amount_cents": 99999},
+    )
+    assert res.status_code == 200
+    assert res.json()["amount_cents"] == 99999
+    assert res.json()["recurrence_config"] == {"days": [10, 25]}
+
+
 async def test_toggle_bill_enabled(client: AsyncClient):
     account = await _create_account(client)
     bill = (

--- a/backend/tests/test_bills_csv.py
+++ b/backend/tests/test_bills_csv.py
@@ -1,0 +1,137 @@
+from datetime import date
+
+from src.bills_csv import CSV_COLUMNS, bills_to_csv, parse_csv_rows
+from src.models.bill import Bill, RecurrenceType
+
+
+def _bill(**overrides) -> Bill:
+    defaults = dict(
+        id=1,
+        account_id=1,
+        name="Rent",
+        amount_cents=150000,
+        recurrence_type=RecurrenceType.MONTHLY,
+        recurrence_config={},
+        start_date=date(2026, 1, 1),
+        end_date=None,
+        enabled=True,
+        notes=None,
+    )
+    defaults.update(overrides)
+    return Bill(**defaults)
+
+
+class TestBillsToCsv:
+    def test_round_trips_basic_fields(self):
+        csv_text = bills_to_csv([_bill(notes="fixed rate")])
+        bills, errors = parse_csv_rows(csv_text)
+
+        assert errors == []
+        assert len(bills) == 1
+        assert bills[0].name == "Rent"
+        assert bills[0].amount_cents == 150000
+        assert bills[0].notes == "fixed rate"
+
+    def test_semimonthly_days_flattened_into_own_column(self):
+        bill = _bill(
+            recurrence_type=RecurrenceType.SEMIMONTHLY, recurrence_config={"days": [10, 25]}
+        )
+        csv_text = bills_to_csv([bill])
+
+        assert "10,25" in csv_text
+        bills, errors = parse_csv_rows(csv_text)
+        assert errors == []
+        assert bills[0].recurrence_config == {"days": [10, 25]}
+
+    def test_custom_days_interval_flattened_into_own_column(self):
+        bill = _bill(
+            recurrence_type=RecurrenceType.CUSTOM_DAYS, recurrence_config={"interval_days": 45}
+        )
+        csv_text = bills_to_csv([bill])
+
+        bills, errors = parse_csv_rows(csv_text)
+        assert errors == []
+        assert bills[0].recurrence_config == {"interval_days": 45}
+
+    def test_header_matches_csv_columns_constant(self):
+        csv_text = bills_to_csv([])
+        header = csv_text.splitlines()[0]
+        assert header == ",".join(CSV_COLUMNS)
+
+
+class TestParseCsvRows:
+    def test_missing_required_field_reports_row_number(self):
+        csv_text = (
+            "name,amount,recurrence_type,semimonthly_days,custom_interval_days,"
+            "start_date,end_date,enabled,notes\n"
+            ",100.00,monthly,,,2026-01-01,,true,\n"
+        )
+        bills, errors = parse_csv_rows(csv_text)
+
+        assert bills == []
+        assert len(errors) == 1
+        assert errors[0].row == 2
+        assert "name" in errors[0].message
+
+    def test_invalid_recurrence_type_reports_error(self):
+        csv_text = (
+            "name,amount,recurrence_type,semimonthly_days,custom_interval_days,"
+            "start_date,end_date,enabled,notes\n"
+            "Rent,100.00,bogus,,,2026-01-01,,true,\n"
+        )
+        bills, errors = parse_csv_rows(csv_text)
+
+        assert bills == []
+        assert len(errors) == 1
+        assert "recurrence_type" in errors[0].message
+
+    def test_semimonthly_without_days_reports_error(self):
+        csv_text = (
+            "name,amount,recurrence_type,semimonthly_days,custom_interval_days,"
+            "start_date,end_date,enabled,notes\n"
+            "Rent,100.00,semimonthly,,,2026-01-01,,true,\n"
+        )
+        bills, errors = parse_csv_rows(csv_text)
+
+        assert bills == []
+        assert len(errors) == 1
+        assert "semimonthly_days" in errors[0].message
+
+    def test_reports_the_bad_row_alongside_successfully_parsed_rows(self):
+        # parse_csv_rows itself returns partial results (both the rows that
+        # parsed fine and the ones that didn't) - it's the API layer
+        # (import_bills) that enforces all-or-nothing by discarding `bills`
+        # whenever `errors` is non-empty, never calling this twice.
+        csv_text = (
+            "name,amount,recurrence_type,semimonthly_days,custom_interval_days,"
+            "start_date,end_date,enabled,notes\n"
+            "Rent,100.00,monthly,,,2026-01-01,,true,\n"
+            ",50.00,monthly,,,2026-01-01,,true,\n"
+        )
+        bills, errors = parse_csv_rows(csv_text)
+
+        assert len(bills) == 1
+        assert bills[0].name == "Rent"
+        assert len(errors) == 1
+        assert errors[0].row == 3
+
+    def test_short_row_with_missing_trailing_columns_does_not_crash(self):
+        # csv.DictReader fills missing trailing fields with None (not ""),
+        # which previously crashed with AttributeError on `.strip()`.
+        csv_text = "name,amount,recurrence_type,semimonthly_days,custom_interval_days,start_date\nRent,100.00,monthly\n"
+        bills, errors = parse_csv_rows(csv_text)
+
+        assert bills == []
+        assert len(errors) == 1
+        assert "start_date" in errors[0].message
+
+    def test_enabled_defaults_to_true_when_blank(self):
+        csv_text = (
+            "name,amount,recurrence_type,semimonthly_days,custom_interval_days,"
+            "start_date,end_date,enabled,notes\n"
+            "Rent,100.00,monthly,,,2026-01-01,,,\n"
+        )
+        bills, errors = parse_csv_rows(csv_text)
+
+        assert errors == []
+        assert bills[0].enabled is True

--- a/backend/tests/test_bills_csv.py
+++ b/backend/tests/test_bills_csv.py
@@ -95,7 +95,11 @@ class TestParseCsvRows:
 
         assert bills == []
         assert len(errors) == 1
-        assert "semimonthly_days" in errors[0].message
+        # Message now comes from the shared validate_recurrence_config
+        # (backend/src/forecast/bill.py), the same one the JSON create/update
+        # API path uses - "recurrence_config.days" rather than the CSV
+        # column name, but consistent across both paths.
+        assert "days" in errors[0].message
 
     def test_reports_the_bad_row_alongside_successfully_parsed_rows(self):
         # parse_csv_rows itself returns partial results (both the rows that

--- a/backend/tests/test_forecast_api.py
+++ b/backend/tests/test_forecast_api.py
@@ -1,8 +1,12 @@
+from datetime import date
+
 import pytest
 from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.core.auth import get_current_user
 from src.main import app
+from src.models import Bill, RecurrenceType
 from tests.conftest import auth_as
 
 
@@ -103,12 +107,25 @@ async def test_forecast_excludes_disabled_bills(client: AsyncClient):
     assert body["ending_balance_cents"] == 100000 + 200000 * 2
 
 
-async def test_forecast_reports_bills_missing_recurrence_config(client: AsyncClient):
+async def test_forecast_reports_bills_missing_recurrence_config(
+    client: AsyncClient, db_session: AsyncSession
+):
+    # create_bill now rejects a missing/invalid recurrence_config outright
+    # (422), so a bill can only end up in this state via data that predates
+    # that validation (or a direct DB write) - insert one directly to
+    # exercise the forecast engine's defensive unscheduled_bills handling.
     account = await _create_account(client)
-    await client.post(
-        f"/api/v1/accounts/{account['id']}/bills",
-        json=_bill_payload(recurrence_type="custom_days"),
+    bill = Bill(
+        account_id=account["id"],
+        name="Rent",
+        amount_cents=150000,
+        recurrence_type=RecurrenceType.CUSTOM_DAYS,
+        recurrence_config={},
+        start_date=date(2024, 1, 15),
+        enabled=True,
     )
+    db_session.add(bill)
+    await db_session.commit()
 
     res = await client.post(
         f"/api/v1/accounts/{account['id']}/forecast", json=_forecast_payload()

--- a/backend/tests/test_forecast_engine.py
+++ b/backend/tests/test_forecast_engine.py
@@ -219,13 +219,13 @@ class TestRecurrenceConfigValidation:
             recurrence_type=RecurrenceType.SEMIMONTHLY,
             recurrence_config={"days": [10, 25]},
         )
-        assert validate_recurrence_config(bill) is None
+        assert validate_recurrence_config(bill.recurrence_type, bill.recurrence_config) is None
         occurrences = occurrences_in_range(bill, date(2024, 3, 1), date(2024, 3, 31))
         assert occurrences == [date(2024, 3, 10), date(2024, 3, 25)]
 
     def test_semimonthly_missing_config_raises(self):
         bill = make_bill(1, "rent", 50000, date(2024, 1, 1), recurrence_type=RecurrenceType.SEMIMONTHLY)
-        assert validate_recurrence_config(bill) is not None
+        assert validate_recurrence_config(bill.recurrence_type, bill.recurrence_config) is not None
 
     @pytest.mark.parametrize("days", [[0, 25], [10, 32], [-5, 10]])
     def test_semimonthly_out_of_range_days_raises_instead_of_crashing(self, days):
@@ -237,7 +237,7 @@ class TestRecurrenceConfigValidation:
             recurrence_type=RecurrenceType.SEMIMONTHLY,
             recurrence_config={"days": days},
         )
-        assert validate_recurrence_config(bill) is not None
+        assert validate_recurrence_config(bill.recurrence_type, bill.recurrence_config) is not None
         with pytest.raises(MissingRecurrenceConfig):
             occurrences_in_range(bill, date(2024, 3, 1), date(2024, 3, 31))
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -190,7 +190,7 @@ per-PR preview branch) make manual Neon console clicks a recurring chore.
 
 ## Phase 0 — Foundations
 
-**Status**: code complete; one follow-up item below (0.6)
+**Status**: code complete
 
 - [x] 0.1 Finalize data model (turn the sketch above into real SQLAlchemy models + an ER
       diagram in this doc)
@@ -209,23 +209,17 @@ per-PR preview branch) make manual Neon console clicks a recurring chore.
       `PUBLIC_AUTH0_CLIENT_ID`/`PUBLIC_AUTH0_AUDIENCE` filled in `frontend/.env` (see
       `frontend/.env.example`), and the dev URL (`http://localhost:5173`) added as an
       Allowed Callback/Logout/Web Origin URL in the Auth0 SPA application settings.
-- [ ] 0.6 Local dev auth bypass: an opt-in flag (env var, off by default) that skips real
-      Auth0 token validation entirely and JIT-provisions a fixed dummy user, so
-      `docker compose up` can be exercised end-to-end (including by an AI coding
-      assistant in a sandboxed environment) without a real Auth0 login. Dummy identity
-      themed as an It's Always Sunny in Philadelphia character, with an email-shaped
-      display name - e.g. `charlie.kelly@paddys.bar` - close enough to a real Auth0
-      `sub`/`email` claim pair that `get_current_db_user`'s JIT-provisioning path
-      (`backend/src/api/deps.py`) needs no special-casing for it. Backend:
-      short-circuit `get_current_user` (`backend/src/core/auth.py`) when the bypass flag
-      is set, skipping the JWKS fetch/JWT decode entirely. Frontend: skip the Auth0 SPA
-      redirect (`frontend/src/lib/auth.ts`) the same way, so login is instant locally.
-      **Must never be reachable in prod** - gate behind an explicit env var checked at
-      startup, never a request header/query param a client could set.
+- [x] 0.6 Local dev auth bypass: `DEV_AUTH_BYPASS`/`PUBLIC_DEV_AUTH_BYPASS` env vars (off by
+      default, never set in a deployed environment - nothing in `infra/` sets them). Backend
+      short-circuits `get_current_user` (`backend/src/core/auth.py`) before touching
+      JWKS/jose at all; frontend short-circuits `initAuth`/`login`/`logout`/`getAccessToken`
+      (`frontend/src/lib/auth.ts`). Dummy identity: `auth0|charlie_kelly_dev` /
+      `charlie.kelly@paddys.bar`, JIT-provisioned through the normal
+      `get_current_db_user` path with no special-casing needed.
 
 ## Phase 1 — Accounts & Bills CRUD
 
-**Status**: code complete; follow-up items below (1.7-1.9)
+**Status**: code complete
 
 - [x] 1.1 Backend: `bank_accounts` CRUD API, scoped to the authenticated user
 - [x] 1.2 Backend: `bills` CRUD API, scoped to an account, including the enable/disable
@@ -245,26 +239,26 @@ per-PR preview branch) make manual Neon console clicks a recurring chore.
       pop-up modal where the user can select an account to move the bill to; once applied
       the bills list is updated to show the current list of bills sans the bill that was
       moved.
-- [ ] 1.7 Recurrence-specific config UI for the bill form — **not yet designed, scope
-      before starting**. Today `createBill` never sends `recurrence_config`
-      (`frontend/src/routes/(app)/accounts/[id]/+page.svelte`), so every bill gets created
-      with an empty `{}` regardless of type, even though the model needs type-specific data:
-      `{"interval_days": N}` (custom_days), `{"days": [10, 25]}` (semimonthly),
-      `{"day_of_month": N}` (monthly), and likely a weekday (weekly/biweekly) or month+day
-      (annually). Needs per-type conditional form fields on both create and edit. Blocks
-      exercising Phase 2's forecast engine end-to-end against real user-created bills of
-      non-trivial recurrence types.
-- [ ] 1.8 Bills CSV import/export per bank account. Backend: add account-scoped export and
-      import endpoints for the full bills list, with validation/error reporting granular
-      enough for a user-edited CSV. Frontend: add import/export actions on the bills page
-      for the current account, with a downloadable template/example. CSV should stay
-      human-readable and spreadsheet-friendly (Excel/Numbers), especially for money:
-      amounts should be rendered and accepted in the selected display currency (default
-      USD), while the backend continues storing normalized cents.
-- [ ] 1.9 Bill notes support. Backend: extend `bills` schema + create/update/read endpoints with
-      optional `notes` text (`NULL`/empty allowed). Frontend: add notes field to bill create/edit
-      form and display in the bills table/detail affordance. Notes are persistent bill metadata
-      and apply to all future cycles for that bill.
+- [x] 1.7 Recurrence-specific config UI for the bill form, on both create and a new bill
+      edit modal (none existed before - the roadmap's "on both create and edit" phrasing
+      meant building one). New shared `RecurrenceConfigFields.svelte` renders per-type
+      fields (nothing for weekly/biweekly/monthly/annually; two 1-31 day inputs defaulting
+      to `[10, 25]` for semimonthly; one interval input defaulting to 30 for custom_days)
+      and both the create form and edit modal now actually send `recurrence_config`
+      (previously always omitted). Also rebuilt `Select.svelte` as a custom Tailwind
+      popover listbox (mirroring `DatePicker.svelte`'s pattern) instead of a native
+      `<select>`, since this item needed more per-type fields on top of it.
+- [x] 1.8 Bills CSV import/export per bank account. Backend: `GET/POST
+      .../bills/{export,import}` (`backend/src/bills_csv.py`, `backend/src/api/bills.py`) -
+      dollars not cents, `semimonthly_days`/`custom_interval_days` as their own columns
+      instead of raw JSON, all-or-nothing import validation (a 422 with a per-row error
+      list if any row fails, nothing inserted). Frontend: Import/Export buttons on the
+      bills page (`frontend/src/lib/api/bills.ts`'s `exportBillsCsv`/`importBillsCsv`, via
+      `apiFetch` directly rather than `apiJson` since a CSV blob/multipart upload isn't
+      JSON).
+- [x] 1.9 Bill notes support. `Bill.notes` (nullable, migration `12aa348bb14f`), threaded
+      through `BillCreate`/`Update`/`Read` and the create form + edit modal (no dedicated
+      bills-table column, to avoid clutter - the edit modal is the "detail affordance").
 
 ## Phase 2 — Forecast Engine
 
@@ -526,3 +520,17 @@ session (or a fresh Claude Code instance) orient in under a minute.
   Tally-specific vocabulary), and 4.6 (a real logged-out homepage with an interactive,
   no-login forecast demo reusing the real engine via a new public endpoint). Next: 1.7,
   Phase 4, or any of the newly-logged follow-ups.
+- 2026-07-12: Shipped the Phase 0/1 follow-up items in one PR: 0.6 (dev auth bypass), 1.7
+  (recurrence-config UI + the first bill edit modal), 1.8 (CSV import/export), and 1.9
+  (bill notes) - plus rebuilding `Select.svelte` as a custom Tailwind dropdown (a
+  standalone request that landed alongside 1.7 since that item needed more per-type
+  select/number fields on top of it). Verified end-to-end in a real browser via the new
+  dev-auth-bypass flow (Playwright, headless). Also fixed an unrelated production bug
+  first this session: SPA deep-link refreshes (e.g. `/dashboard`) were returning a raw S3
+  `AccessDenied` XML instead of the app, because CloudFront's OAC-protected S3 origin
+  returns 403 (not 404) for a missing key and the S3 bucket's `error_document` setting
+  never applied (it only works on S3's website endpoint, which OAC doesn't use) - fixed
+  with `custom_error_response` blocks on the CloudFront distribution (PR #90). Next: Phase
+  3 cycle reconciliation (3.5-3.11 - `cycle_overrides` data model/migration, CRUD, forecast
+  engine integration, active-cycle frontend controls, reconciliation summary, bill
+  history), or any Phase 4 item.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -6,3 +6,8 @@ PUBLIC_AUTH0_CLIENT_ID=your-auth0-spa-client-id
 PUBLIC_AUTH0_AUDIENCE=https://api.tally.example.com
 
 PUBLIC_API_BASE_URL=http://localhost:8000
+
+# Local dev only — skips the Auth0 SPA redirect and logs in as a fixed dummy
+# user (must match the backend's DEV_AUTH_BYPASS). NEVER set this to true in
+# a deployed environment.
+PUBLIC_DEV_AUTH_BYPASS=false

--- a/frontend/src/lib/api/bills.ts
+++ b/frontend/src/lib/api/bills.ts
@@ -1,4 +1,4 @@
-import { apiJson } from '$lib/api';
+import { apiFetch, apiJson, ApiError } from '$lib/api';
 import type { Bill, BillInput } from '$lib/api/types';
 
 export function listBills(accountId: number): Promise<Bill[]> {
@@ -25,4 +25,30 @@ export function updateBill(
 
 export function deleteBill(accountId: number, billId: number): Promise<void> {
 	return apiJson(`/api/v1/accounts/${accountId}/bills/${billId}`, { method: 'DELETE' });
+}
+
+export async function exportBillsCsv(accountId: number): Promise<Blob> {
+	const res = await apiFetch(`/api/v1/accounts/${accountId}/bills/export`);
+	if (!res.ok) throw new ApiError(res.status, await res.text());
+	return res.blob();
+}
+
+export interface BillImportRowError {
+	row: number;
+	message: string;
+}
+
+export async function importBillsCsv(accountId: number, file: File): Promise<Bill[]> {
+	const formData = new FormData();
+	formData.append('file', file);
+	// apiFetch, not apiJson - a FormData body must NOT have a Content-Type set
+	// manually (the browser generates the multipart boundary itself); apiJson
+	// would force Content-Type: application/json since none is passed here.
+	const res = await apiFetch(`/api/v1/accounts/${accountId}/bills/import`, {
+		method: 'POST',
+		body: formData
+	});
+	const body = await res.json();
+	if (!res.ok) throw new ApiError(res.status, body);
+	return body;
 }

--- a/frontend/src/lib/api/bills.ts
+++ b/frontend/src/lib/api/bills.ts
@@ -48,7 +48,13 @@ export async function importBillsCsv(accountId: number, file: File): Promise<Bil
 		method: 'POST',
 		body: formData
 	});
-	const body = await res.json();
-	if (!res.ok) throw new ApiError(res.status, body);
-	return body;
+	if (!res.ok) {
+		// Mirrors apiJson's error-body handling: an error response isn't
+		// guaranteed to be JSON (e.g. a proxy's 502/504 page), so a raw
+		// res.json() here could throw a parse error instead of a clean
+		// ApiError.
+		const body = await res.json().catch(() => null);
+		throw new ApiError(res.status, body);
+	}
+	return res.json();
 }

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -38,6 +38,7 @@ export interface Bill {
 	start_date: string;
 	end_date: string | null;
 	enabled: boolean;
+	notes: string | null;
 	created_at: string;
 	updated_at: string;
 }
@@ -50,6 +51,7 @@ export interface BillInput {
 	start_date: string;
 	end_date?: string | null;
 	enabled?: boolean;
+	notes?: string | null;
 }
 
 export interface Transaction {

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -76,7 +76,16 @@ export async function initAuth(): Promise<void> {
 
 export async function login(redirectTo?: string): Promise<void> {
 	if (!browser) return;
-	if (DEV_AUTH_BYPASS) return; // already "logged in" via initAuth()
+	if (DEV_AUTH_BYPASS) {
+		// Restores the dummy identity rather than no-op'ing - logout() (below)
+		// sets isAuthenticated=false with no real session to redirect through,
+		// and the (app)/+layout.svelte guard calls login() to recover from
+		// exactly that state, so a no-op here would leave the app permanently
+		// stuck unauthenticated after a bypass logout.
+		isAuthenticated.set(true);
+		user.set(DEV_USER);
+		return;
+	}
 	try {
 		const targetRedirect = redirectTo ?? window.location.pathname;
 		// No authorizationParams override here - the constructor's (redirect_uri,

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -3,10 +3,17 @@ import { goto } from '$app/navigation';
 import {
 	PUBLIC_AUTH0_AUDIENCE,
 	PUBLIC_AUTH0_CLIENT_ID,
-	PUBLIC_AUTH0_DOMAIN
+	PUBLIC_AUTH0_DOMAIN,
+	PUBLIC_DEV_AUTH_BYPASS
 } from '$env/static/public';
 import { Auth0Client, type User } from '@auth0/auth0-spa-js';
 import { writable } from 'svelte/store';
+
+// Must match the backend's dev_auth_bypass dummy identity (see
+// get_current_user in backend/src/core/auth.py) — never true in a deployed
+// environment (see PUBLIC_DEV_AUTH_BYPASS in .env.example).
+const DEV_AUTH_BYPASS = PUBLIC_DEV_AUTH_BYPASS === 'true';
+const DEV_USER = { sub: 'auth0|charlie_kelly_dev', email: 'charlie.kelly@paddys.bar' } as User;
 
 export const isAuthenticated = writable(false);
 export const isLoading = writable(true);
@@ -33,6 +40,13 @@ function getClient(): Auth0Client {
 // (this app is a static SPA — see svelte.config.js's adapter-static).
 export async function initAuth(): Promise<void> {
 	if (!browser) return;
+
+	if (DEV_AUTH_BYPASS) {
+		isAuthenticated.set(true);
+		user.set(DEV_USER);
+		isLoading.set(false);
+		return;
+	}
 
 	try {
 		const auth0 = getClient();
@@ -62,6 +76,7 @@ export async function initAuth(): Promise<void> {
 
 export async function login(redirectTo?: string): Promise<void> {
 	if (!browser) return;
+	if (DEV_AUTH_BYPASS) return; // already "logged in" via initAuth()
 	try {
 		const targetRedirect = redirectTo ?? window.location.pathname;
 		// No authorizationParams override here - the constructor's (redirect_uri,
@@ -81,6 +96,11 @@ export async function login(redirectTo?: string): Promise<void> {
 
 export async function logout(): Promise<void> {
 	if (!browser) return;
+	if (DEV_AUTH_BYPASS) {
+		isAuthenticated.set(false);
+		user.set(undefined);
+		return;
+	}
 	try {
 		await getClient().logout({ logoutParams: { returnTo: window.location.origin } });
 	} catch (err) {
@@ -90,5 +110,6 @@ export async function logout(): Promise<void> {
 
 export async function getAccessToken(): Promise<string> {
 	if (!browser) throw new Error('getAccessToken() can only be called in the browser');
+	if (DEV_AUTH_BYPASS) return 'dev-bypass-token'; // never inspected by the backend bypass
 	return getClient().getTokenSilently();
 }

--- a/frontend/src/lib/components/RecurrenceConfigFields.svelte
+++ b/frontend/src/lib/components/RecurrenceConfigFields.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+	import Input from '$lib/components/Input.svelte';
+	import type { RecurrenceType } from '$lib/api/types';
+
+	// Only semimonthly and custom_days need any recurrence_config at all -
+	// see validate_recurrence_config (backend/src/forecast/bill.py), the
+	// authoritative spec for these shapes. Every other type derives its
+	// interval from start_date alone.
+	let {
+		recurrenceType,
+		recurrenceConfig = $bindable({})
+	}: {
+		recurrenceType: RecurrenceType;
+		recurrenceConfig: Record<string, unknown>;
+	} = $props();
+
+	const initialDays = Array.isArray(recurrenceConfig.days) ? recurrenceConfig.days : [10, 25];
+	let day1 = $state(String(initialDays[0] ?? 10));
+	let day2 = $state(String(initialDays[1] ?? 25));
+	let intervalDays = $state(
+		String(
+			typeof recurrenceConfig.interval_days === 'number' ? recurrenceConfig.interval_days : 30
+		)
+	);
+
+	// Only reads local $state (day1/day2/intervalDays) and recurrenceType, so
+	// writing recurrenceConfig here doesn't re-trigger this same effect.
+	$effect(() => {
+		if (recurrenceType === 'semimonthly') {
+			recurrenceConfig = { days: [Number(day1) || 10, Number(day2) || 25] };
+		} else if (recurrenceType === 'custom_days') {
+			recurrenceConfig = { interval_days: Number(intervalDays) || 30 };
+		} else {
+			recurrenceConfig = {};
+		}
+	});
+</script>
+
+{#if recurrenceType === 'semimonthly'}
+	<Input label="Day 1 (1-31)" type="number" bind:value={day1} />
+	<Input label="Day 2 (1-31)" type="number" bind:value={day2} />
+{:else if recurrenceType === 'custom_days'}
+	<Input label="Every N days" type="number" bind:value={intervalDays} />
+{/if}

--- a/frontend/src/lib/components/Select.svelte
+++ b/frontend/src/lib/components/Select.svelte
@@ -1,33 +1,78 @@
 <script lang="ts">
-	import type { Snippet } from 'svelte';
-
 	let {
 		label,
 		value = $bindable(''),
 		id,
 		required = false,
-		children
+		options
 	}: {
 		label?: string;
 		value?: string;
 		id?: string;
 		required?: boolean;
-		children: Snippet;
+		options: { value: string; label: string }[];
 	} = $props();
 
 	const selectId = id ?? label?.toLowerCase().replace(/\s+/g, '-');
+
+	let open = $state(false);
+	let containerEl = $state<HTMLDivElement | undefined>();
+
+	const selectedLabel = $derived(options.find((o) => o.value === value)?.label ?? '');
+
+	function pick(optionValue: string) {
+		value = optionValue;
+		open = false;
+	}
+
+	function handleWindowClick(event: MouseEvent) {
+		if (open && containerEl && !containerEl.contains(event.target as Node)) {
+			open = false;
+		}
+	}
+
+	function handleKeydown(event: KeyboardEvent) {
+		if (event.key === 'Escape') open = false;
+	}
 </script>
 
-<div class="flex flex-col gap-1">
+<svelte:window onclick={handleWindowClick} onkeydown={open ? handleKeydown : undefined} />
+
+<div class="relative flex flex-col gap-1" bind:this={containerEl}>
 	{#if label}
 		<label for={selectId} class="text-sm font-medium text-text">{label}</label>
 	{/if}
-	<select
+	<button
+		type="button"
 		id={selectId}
-		{required}
-		bind:value
-		class="rounded-card border border-slate-300 px-3 py-2 text-sm text-text focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+		onclick={() => (open = !open)}
+		aria-haspopup="listbox"
+		aria-expanded={open}
+		class="flex items-center justify-between gap-2 rounded-card border border-slate-300 bg-surface px-3 py-2 text-left text-sm text-text focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
 	>
-		{@render children()}
-	</select>
+		<span>{selectedLabel || 'Select…'}</span>
+		<span class="text-slate-400">▾</span>
+	</button>
+
+	{#if open}
+		<div
+			class="absolute top-full z-10 mt-1 w-full min-w-max rounded-card border border-slate-200 bg-surface py-1 shadow-card"
+			role="listbox"
+		>
+			{#each options as option (option.value)}
+				<button
+					type="button"
+					role="option"
+					aria-selected={option.value === value}
+					onclick={() => pick(option.value)}
+					class="block w-full px-3 py-2 text-left text-sm hover:bg-slate-100 {option.value ===
+					value
+						? 'bg-slate-50 font-medium text-primary'
+						: 'text-text'}"
+				>
+					{option.label}
+				</button>
+			{/each}
+		</div>
+	{/if}
 </div>

--- a/frontend/src/lib/components/Select.svelte
+++ b/frontend/src/lib/components/Select.svelte
@@ -3,13 +3,11 @@
 		label,
 		value = $bindable(''),
 		id,
-		required = false,
 		options
 	}: {
 		label?: string;
 		value?: string;
 		id?: string;
-		required?: boolean;
 		options: { value: string; label: string }[];
 	} = $props();
 
@@ -17,6 +15,7 @@
 
 	let open = $state(false);
 	let containerEl = $state<HTMLDivElement | undefined>();
+	let optionEls: (HTMLButtonElement | undefined)[] = [];
 
 	const selectedLabel = $derived(options.find((o) => o.value === value)?.label ?? '');
 
@@ -25,14 +24,47 @@
 		open = false;
 	}
 
+	function focusOption(index: number) {
+		optionEls[index]?.focus();
+	}
+
+	function openAndFocusSelected() {
+		open = true;
+		const selectedIndex = options.findIndex((o) => o.value === value);
+		// Wait for the {#if open} popover to mount before focusing into it.
+		requestAnimationFrame(() => focusOption(selectedIndex >= 0 ? selectedIndex : 0));
+	}
+
 	function handleWindowClick(event: MouseEvent) {
 		if (open && containerEl && !containerEl.contains(event.target as Node)) {
 			open = false;
 		}
 	}
 
+	// Roving focus among the option buttons, matching the WAI-ARIA listbox
+	// pattern implied by role="listbox"/role="option" below - without this,
+	// a keyboard user could only Tab through options one at a time with no
+	// arrow-key navigation, unlike the native <select> this replaced.
 	function handleKeydown(event: KeyboardEvent) {
-		if (event.key === 'Escape') open = false;
+		if (event.key === 'Escape') {
+			open = false;
+			return;
+		}
+		if (!open) return;
+		const currentIndex = optionEls.findIndex((el) => el === document.activeElement);
+		if (event.key === 'ArrowDown') {
+			event.preventDefault();
+			focusOption(currentIndex < options.length - 1 ? currentIndex + 1 : 0);
+		} else if (event.key === 'ArrowUp') {
+			event.preventDefault();
+			focusOption(currentIndex > 0 ? currentIndex - 1 : options.length - 1);
+		} else if (event.key === 'Home') {
+			event.preventDefault();
+			focusOption(0);
+		} else if (event.key === 'End') {
+			event.preventDefault();
+			focusOption(options.length - 1);
+		}
 	}
 </script>
 
@@ -45,7 +77,7 @@
 	<button
 		type="button"
 		id={selectId}
-		onclick={() => (open = !open)}
+		onclick={() => (open ? (open = false) : openAndFocusSelected())}
 		aria-haspopup="listbox"
 		aria-expanded={open}
 		class="flex items-center justify-between gap-2 rounded-card border border-slate-300 bg-surface px-3 py-2 text-left text-sm text-text focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
@@ -59,11 +91,12 @@
 			class="absolute top-full z-10 mt-1 w-full min-w-max rounded-card border border-slate-200 bg-surface py-1 shadow-card"
 			role="listbox"
 		>
-			{#each options as option (option.value)}
+			{#each options as option, i (option.value)}
 				<button
 					type="button"
 					role="option"
 					aria-selected={option.value === value}
+					bind:this={optionEls[i]}
 					onclick={() => pick(option.value)}
 					class="block w-full px-3 py-2 text-left text-sm hover:bg-slate-100 {option.value ===
 					value

--- a/frontend/src/routes/(app)/accounts/[id]/+page.svelte
+++ b/frontend/src/routes/(app)/accounts/[id]/+page.svelte
@@ -49,6 +49,7 @@
 	let startDate = $state('');
 	let notes = $state('');
 	let creating = $state(false);
+	let recurrenceFieldsResetKey = $state(0);
 
 	let movingBill = $state<Bill | null>(null);
 	let moveTargetAccountId = $state('');
@@ -104,7 +105,10 @@
 	async function handleCreate(event: SubmitEvent) {
 		event.preventDefault();
 		const amountCents = Math.round(Number(amount) * 100);
-		if (!name.trim() || !startDate || Number.isNaN(amountCents)) return;
+		if (!name.trim() || !startDate || Number.isNaN(amountCents)) {
+			error = 'Please fill out all required fields.';
+			return;
+		}
 		creating = true;
 		try {
 			await createBill(accountId, {
@@ -118,6 +122,11 @@
 			name = '';
 			amount = '';
 			recurrenceConfig = {};
+			// RecurrenceConfigFields only seeds its local day/interval inputs
+			// from recurrenceConfig once at mount - remounting it (via the
+			// {#key} block below) is what makes the reset above actually
+			// clear what's displayed, not just the value bound to the parent.
+			recurrenceFieldsResetKey += 1;
 			startDate = '';
 			notes = '';
 			await loadBills();
@@ -308,7 +317,9 @@
 			bind:value={recurrenceType}
 			options={recurrenceOptions.map((option) => ({ value: option, label: recurrenceLabels[option] }))}
 		/>
-		<RecurrenceConfigFields {recurrenceType} bind:recurrenceConfig />
+		{#key recurrenceFieldsResetKey}
+			<RecurrenceConfigFields {recurrenceType} bind:recurrenceConfig />
+		{/key}
 		<DatePicker label="Start date" bind:value={startDate} />
 		<Input label="Notes" bind:value={notes} placeholder="Optional" />
 		<Button type="submit" disabled={creating}>Add bill</Button>
@@ -365,7 +376,6 @@
 			<Select
 				label="Account"
 				bind:value={moveTargetAccountId}
-				required
 				options={accounts
 					.filter((a) => a.id !== accountId)
 					.map((target) => ({ value: String(target.id), label: target.name }))}

--- a/frontend/src/routes/(app)/accounts/[id]/+page.svelte
+++ b/frontend/src/routes/(app)/accounts/[id]/+page.svelte
@@ -1,7 +1,16 @@
 <script lang="ts">
 	import { page } from '$app/stores';
 	import { getAccount, listAccounts } from '$lib/api/accounts';
-	import { createBill, deleteBill, listBills, updateBill } from '$lib/api/bills';
+	import {
+		createBill,
+		deleteBill,
+		exportBillsCsv,
+		importBillsCsv,
+		listBills,
+		updateBill,
+		type BillImportRowError
+	} from '$lib/api/bills';
+	import { ApiError } from '$lib/api';
 	import type { BankAccount, Bill, RecurrenceType } from '$lib/api/types';
 	import AccountNav from '$lib/components/AccountNav.svelte';
 	import Badge from '$lib/components/Badge.svelte';
@@ -10,6 +19,7 @@
 	import DatePicker from '$lib/components/DatePicker.svelte';
 	import Input from '$lib/components/Input.svelte';
 	import Modal from '$lib/components/Modal.svelte';
+	import RecurrenceConfigFields from '$lib/components/RecurrenceConfigFields.svelte';
 	import Select from '$lib/components/Select.svelte';
 	import Table from '$lib/components/Table.svelte';
 	import { recurrenceLabels } from '$lib/recurrence';
@@ -35,13 +45,32 @@
 	let name = $state('');
 	let amount = $state('');
 	let recurrenceType = $state<RecurrenceType>('monthly');
+	let recurrenceConfig = $state<Record<string, unknown>>({});
 	let startDate = $state('');
+	let notes = $state('');
 	let creating = $state(false);
 
 	let movingBill = $state<Bill | null>(null);
 	let moveTargetAccountId = $state('');
 	let moving = $state(false);
 	let showMoveModal = $state(false);
+
+	let exporting = $state(false);
+	let importing = $state(false);
+	let importErrors = $state<BillImportRowError[] | null>(null);
+	let fileInputEl = $state<HTMLInputElement | undefined>();
+
+	let editingBill = $state<Bill | null>(null);
+	let editName = $state('');
+	let editAmount = $state('');
+	let editRecurrenceType = $state<RecurrenceType>('monthly');
+	let editRecurrenceConfig = $state<Record<string, unknown>>({});
+	let editStartDate = $state('');
+	let editEndDate = $state('');
+	let editEnabled = $state(true);
+	let editNotes = $state('');
+	let saving = $state(false);
+	let showEditModal = $state(false);
 
 	// Account details and the accounts list (for the move-bill picker) only
 	// change when navigating here or moving a bill elsewhere entirely - they
@@ -82,11 +111,15 @@
 				name,
 				amount_cents: amountCents,
 				recurrence_type: recurrenceType,
-				start_date: startDate
+				recurrence_config: recurrenceConfig,
+				start_date: startDate,
+				notes: notes || null
 			});
 			name = '';
 			amount = '';
+			recurrenceConfig = {};
 			startDate = '';
+			notes = '';
 			await loadBills();
 		} catch (err) {
 			error = err instanceof Error ? err.message : String(err);
@@ -113,6 +146,54 @@
 		}
 	}
 
+	async function handleExport() {
+		exporting = true;
+		error = null;
+		try {
+			const blob = await exportBillsCsv(accountId);
+			const url = URL.createObjectURL(blob);
+			const link = document.createElement('a');
+			link.href = url;
+			link.download = `bills-${accountId}.csv`;
+			link.click();
+			URL.revokeObjectURL(url);
+		} catch (err) {
+			error = err instanceof Error ? err.message : String(err);
+		} finally {
+			exporting = false;
+		}
+	}
+
+	function handleImportClick() {
+		fileInputEl?.click();
+	}
+
+	async function handleImportFile(event: Event) {
+		const file = (event.target as HTMLInputElement).files?.[0];
+		if (!file) return;
+		importing = true;
+		error = null;
+		importErrors = null;
+		try {
+			await importBillsCsv(accountId, file);
+			await loadBills();
+		} catch (err) {
+			if (err instanceof ApiError && err.body && typeof err.body === 'object' && 'detail' in err.body) {
+				const detail = (err.body as { detail?: { errors?: BillImportRowError[] } }).detail;
+				if (detail?.errors) {
+					importErrors = detail.errors;
+				} else {
+					error = 'Import failed.';
+				}
+			} else {
+				error = err instanceof Error ? err.message : String(err);
+			}
+		} finally {
+			importing = false;
+			if (fileInputEl) fileInputEl.value = '';
+		}
+	}
+
 	function openMoveModal(bill: Bill) {
 		movingBill = bill;
 		moveTargetAccountId = '';
@@ -134,30 +215,102 @@
 		}
 	}
 
+	function openEditModal(bill: Bill) {
+		editingBill = bill;
+		editName = bill.name;
+		editAmount = (bill.amount_cents / 100).toString();
+		editRecurrenceType = bill.recurrence_type;
+		editRecurrenceConfig = { ...bill.recurrence_config };
+		editStartDate = bill.start_date;
+		editEndDate = bill.end_date ?? '';
+		editEnabled = bill.enabled;
+		editNotes = bill.notes ?? '';
+		showEditModal = true;
+	}
+
+	async function handleEditSubmit(event: SubmitEvent) {
+		event.preventDefault();
+		if (!editingBill) return;
+		const amountCents = Math.round(Number(editAmount) * 100);
+		if (!editName.trim() || !editStartDate || Number.isNaN(amountCents)) {
+			error = 'Please fill out all required fields.';
+			return;
+		}
+		saving = true;
+		try {
+			await updateBill(accountId, editingBill.id, {
+				name: editName,
+				amount_cents: amountCents,
+				recurrence_type: editRecurrenceType,
+				recurrence_config: editRecurrenceConfig,
+				start_date: editStartDate,
+				end_date: editEndDate || null,
+				enabled: editEnabled,
+				notes: editNotes || null
+			});
+			showEditModal = false;
+			await loadBills();
+		} catch (err) {
+			error = err instanceof Error ? err.message : String(err);
+		} finally {
+			saving = false;
+		}
+	}
+
 	function formatAmount(cents: number): string {
 		return (cents / 100).toLocaleString(undefined, { style: 'currency', currency: 'USD' });
 	}
 </script>
 
 <AccountNav {accountId} current="bills" />
-<h1 class="mt-2 text-2xl font-semibold text-text">
-	Bills{#if account} ({account.name}{#if account.institution} - {account.institution}{/if}){/if}
-</h1>
+<div class="mt-2 flex items-center justify-between">
+	<h1 class="text-2xl font-semibold text-text">
+		Bills{#if account} ({account.name}{#if account.institution} - {account.institution}{/if}){/if}
+	</h1>
+	<div class="flex gap-2">
+		<input
+			bind:this={fileInputEl}
+			type="file"
+			accept=".csv,text/csv"
+			class="hidden"
+			onchange={handleImportFile}
+		/>
+		<Button variant="secondary" onclick={handleImportClick} disabled={importing}>
+			{importing ? 'Importing…' : 'Import CSV'}
+		</Button>
+		<Button variant="secondary" onclick={handleExport} disabled={exporting}>
+			{exporting ? 'Exporting…' : 'Export CSV'}
+		</Button>
+	</div>
+</div>
 
 {#if error}
 	<p class="mt-4 rounded-card bg-red-50 px-4 py-2 text-sm text-red-700">{error}</p>
+{/if}
+
+{#if importErrors}
+	<div class="mt-4 rounded-card bg-red-50 px-4 py-2 text-sm text-red-700">
+		<p class="font-medium">Import failed - fix these rows and try again:</p>
+		<ul class="mt-1 list-disc pl-5">
+			{#each importErrors as rowError (rowError.row)}
+				<li>Row {rowError.row}: {rowError.message}</li>
+			{/each}
+		</ul>
+	</div>
 {/if}
 
 <Card>
 	<form class="flex flex-wrap items-end gap-4" onsubmit={handleCreate}>
 		<Input label="Name" bind:value={name} placeholder="Rent" required />
 		<Input label="Amount ($)" type="number" bind:value={amount} placeholder="1500.00" required />
-		<Select label="Frequency" bind:value={recurrenceType}>
-			{#each recurrenceOptions as option (option)}
-				<option value={option}>{recurrenceLabels[option]}</option>
-			{/each}
-		</Select>
+		<Select
+			label="Frequency"
+			bind:value={recurrenceType}
+			options={recurrenceOptions.map((option) => ({ value: option, label: recurrenceLabels[option] }))}
+		/>
+		<RecurrenceConfigFields {recurrenceType} bind:recurrenceConfig />
 		<DatePicker label="Start date" bind:value={startDate} />
+		<Input label="Notes" bind:value={notes} placeholder="Optional" />
 		<Button type="submit" disabled={creating}>Add bill</Button>
 	</form>
 </Card>
@@ -191,6 +344,7 @@
 						</td>
 						<td class="px-4 py-2 text-right">
 							<div class="flex justify-end gap-2">
+								<Button variant="secondary" onclick={() => openEditModal(bill)}>Edit</Button>
 								<Button variant="secondary" onclick={() => openMoveModal(bill)}>Move</Button>
 								<Button variant="danger" onclick={() => handleDelete(bill.id)}>Delete</Button>
 							</div>
@@ -208,17 +362,57 @@
 			<p class="text-sm text-slate-600">
 				Move <span class="font-medium text-text">{movingBill.name}</span> to a different account.
 			</p>
-			<Select label="Account" bind:value={moveTargetAccountId} required>
-				<option value="" disabled>Select an account</option>
-				{#each accounts.filter((a) => a.id !== accountId) as target (target.id)}
-					<option value={target.id}>{target.name}</option>
-				{/each}
-			</Select>
+			<Select
+				label="Account"
+				bind:value={moveTargetAccountId}
+				required
+				options={accounts
+					.filter((a) => a.id !== accountId)
+					.map((target) => ({ value: String(target.id), label: target.name }))}
+			/>
 			<div class="flex justify-end gap-2">
 				<Button variant="secondary" type="button" onclick={() => (showMoveModal = false)}>
 					Cancel
 				</Button>
 				<Button type="submit" disabled={moving || !moveTargetAccountId}>Move</Button>
+			</div>
+		</form>
+	{/if}
+</Modal>
+
+<Modal bind:open={showEditModal} title="Edit bill">
+	{#if editingBill}
+		<form class="flex flex-col gap-4" onsubmit={handleEditSubmit}>
+			<Input label="Name" bind:value={editName} required />
+			<Input label="Amount ($)" type="number" bind:value={editAmount} required />
+			<Select
+				label="Frequency"
+				bind:value={editRecurrenceType}
+				options={recurrenceOptions.map((option) => ({ value: option, label: recurrenceLabels[option] }))}
+			/>
+			<RecurrenceConfigFields
+				recurrenceType={editRecurrenceType}
+				bind:recurrenceConfig={editRecurrenceConfig}
+			/>
+			<DatePicker label="Start date" bind:value={editStartDate} />
+			<div class="flex items-end gap-2">
+				<DatePicker label="End date (optional)" bind:value={editEndDate} />
+				{#if editEndDate}
+					<Button variant="secondary" type="button" onclick={() => (editEndDate = '')}>
+						Clear
+					</Button>
+				{/if}
+			</div>
+			<Input label="Notes" bind:value={editNotes} placeholder="Optional" />
+			<label class="flex items-center gap-2 text-sm text-text">
+				<input type="checkbox" bind:checked={editEnabled} />
+				Enabled
+			</label>
+			<div class="flex justify-end gap-2">
+				<Button variant="secondary" type="button" onclick={() => (showEditModal = false)}>
+					Cancel
+				</Button>
+				<Button type="submit" disabled={saving}>Save</Button>
 			</div>
 		</form>
 	{/if}

--- a/frontend/src/routes/(app)/accounts/[id]/forecast/+page.svelte
+++ b/frontend/src/routes/(app)/accounts/[id]/forecast/+page.svelte
@@ -139,11 +139,11 @@
 		/>
 		<DatePicker label="Start date" bind:value={startDate} />
 		<DatePicker label="End date" bind:value={endDate} />
-		<Select label="Cycle" bind:value={cycleType}>
-			{#each cycleTypeOptions as option (option)}
-				<option value={option}>{cycleTypeLabels[option]}</option>
-			{/each}
-		</Select>
+		<Select
+			label="Cycle"
+			bind:value={cycleType}
+			options={cycleTypeOptions.map((option) => ({ value: option, label: cycleTypeLabels[option] }))}
+		/>
 		<Button type="submit" disabled={calculating || loading}>Calculate</Button>
 	</form>
 </Card>


### PR DESCRIPTION
## Summary
- **0.6** - Local dev Auth0 bypass: opt-in `DEV_AUTH_BYPASS`/`PUBLIC_DEV_AUTH_BYPASS` env vars (off by default, never set in a deployed environment) skip real Auth0 validation and JIT-provision a fixed dummy user (`charlie.kelly@paddys.bar`).
- **`Select.svelte` rework** - replaced the native `<select>` with a custom Tailwind popover listbox, mirroring `DatePicker.svelte`'s pattern.
- **1.7** - Per-recurrence-type config fields (new `RecurrenceConfigFields.svelte`) on both the bill create form and a new bill edit modal (none existed before). `recurrence_config` is now actually sent to the backend instead of always being omitted.
- **1.8** - Account-scoped bills CSV export/import (`backend/src/bills_csv.py`) - human-readable columns (dollars, not cents; semimonthly/custom_days config flattened into their own columns instead of raw JSON), all-or-nothing import validation with a per-row error list.
- **1.9** - Nullable `Bill.notes` column, threaded through the schema and both bill forms.

Verified end-to-end in a real browser via the new dev-auth-bypass flow (Playwright, headless) - account creation, bill creation with semimonthly config, the edit modal prefilling correctly, and CSV export/import all confirmed working with zero console errors.

## Test plan
- [x] `poetry run pytest` - 91 passed
- [x] `yarn run check` - 0 errors
- [x] Headless browser pass via the new dev-auth-bypass flow: bill create/edit with recurrence config, CSV export/import round-trip
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
