### PR TITLE
fix: add missing PUBLIC_DEV_AUTH_BYPASS to frontend deploy build env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,19 @@ jobs:
         with:
           node-version-file: ./frontend/.nvmrc
       - name: Test
+        env:
+          # Dummy but present: svelte-kit sync generates $env/static/public's
+          # ambient types from whatever env vars actually exist at sync time,
+          # so svelte-check fails on any var the code imports but this step
+          # doesn't set - exactly the gap that let PR #91 merge without
+          # PUBLIC_DEV_AUTH_BYPASS wired into deploy-frontend.yml, breaking
+          # every deploy until fixed here too. Values don't matter, presence does.
+          PUBLIC_AUTH0_DOMAIN: test.auth0.com
+          PUBLIC_AUTH0_CLIENT_ID: test-client-id
+          PUBLIC_AUTH0_AUDIENCE: https://api.test.example.com
+          PUBLIC_API_BASE_URL: http://localhost:8000
+          PUBLIC_DEV_AUTH_BYPASS: "false"
         run: |
           yarn install --frozen-lockfile
+          yarn run check
           yarn test

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -61,6 +61,10 @@ jobs:
           # Empty: prod frontend and API share an origin via CloudFront's /api/v1/* routing
           # (see infra/main.tf's cloudfront module), so API calls are relative.
           PUBLIC_API_BASE_URL: ""
+          # Hardcoded literal, never a secret - must always be false in a
+          # deployed build. $env/static/public still requires the key to
+          # exist at build time even though the value is fixed here.
+          PUBLIC_DEV_AUTH_BYPASS: "false"
         run: yarn build
 
       - name: Verify Build Output


### PR DESCRIPTION
## Summary
- Every push to `main` since PR #91 merged has failed to deploy: `vite build` errors with `"PUBLIC_DEV_AUTH_BYPASS" is not exported by virtual:env/static/public` because `deploy-frontend.yml`'s Build Assets step never set that env var, and SvelteKit's `$env/static/public` requires every statically-imported public var to exist at build time.
- Fix: added `PUBLIC_DEV_AUTH_BYPASS: "false"` as a hardcoded literal (not a secret) to the build step - it must always be `false` in a deployed build, only its *presence* at build time was missing.
- Verified locally: `yarn build` with this var set succeeds; without it, reproduces the exact CI failure.

Run this fixes: https://github.com/kenhowardpdx/tally/actions/runs/29208829089

This is currently blocking every frontend deploy on `main`, so flagging for a prompt look.

## Test plan
- [x] Reproduced the failure locally (build fails without the var)
- [x] Confirmed the fix resolves it (build succeeds with the var)
- [ ] CI green
- [ ] Deploy Frontend Assets succeeds on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)