### PR TITLE
Phase 5: production hardening (observability, security, cost, DNS, deployment audit, runbook)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,5 +31,7 @@ development guide, including testing GitHub Actions workflows locally with `act`
 
 - [Development Guide](docs/DEVELOPING.md)
 - [Roadmap](docs/ROADMAP.md)
+- [Operations](docs/OPERATIONS.md) — observability, backup/DR, cost, security, deployment
+  audit, DNS decision, and the ops runbook
 - [Branding](docs/BRANDING.md)
 - [Infrastructure](infra/README.md)

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -10,3 +10,7 @@ AUTH0_AUDIENCE=https://api.tally.example.com
 # Local dev only — skips real Auth0 token validation and JIT-provisions a
 # fixed dummy user. NEVER set this to true in a deployed environment.
 DEV_AUTH_BYPASS=false
+
+# Structured (JSON) log level - INFO logs one line per request; DEBUG adds
+# noisy library internals (SQLAlchemy, httpx).
+LOG_LEVEL=INFO

--- a/backend/src/core/config.py
+++ b/backend/src/core/config.py
@@ -21,6 +21,11 @@ class Settings(BaseSettings):
     # never be set in a deployed environment (nothing in infra/ sets this).
     dev_auth_bypass: bool = False
 
+    # Structured (JSON) logging level - see src/core/logging.py. INFO logs one
+    # line per request (method/path/status/duration); DEBUG adds library
+    # internals (SQLAlchemy, httpx) that are noisy for routine operation.
+    log_level: str = "INFO"
+
     @field_validator("database_url_readwrite")
     @classmethod
     def _normalize_for_asyncpg(cls, value: str) -> str:

--- a/backend/src/core/logging.py
+++ b/backend/src/core/logging.py
@@ -1,0 +1,63 @@
+import json
+import logging
+import time
+from collections.abc import Awaitable, Callable
+
+from starlette.requests import Request
+from starlette.responses import Response
+
+from src.core.config import settings
+
+
+class _JsonFormatter(logging.Formatter):
+    # Plain text logging on Lambda still lands in CloudWatch fine, but each
+    # entry is an opaque string - JSON lines let CloudWatch Logs Insights query
+    # individual fields (status_code, duration_ms, path) instead of regexing
+    # message text.
+    def format(self, record: logging.LogRecord) -> str:
+        payload = {
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+        if hasattr(record, "extra_fields"):
+            payload.update(record.extra_fields)
+        if record.exc_info:
+            payload["exc_info"] = self.formatException(record.exc_info)
+        return json.dumps(payload)
+
+
+def configure_logging() -> None:
+    root = logging.getLogger()
+    root.setLevel(settings.log_level)
+
+    # Lambda's runtime already attaches a handler to the root logger before
+    # this ever runs - replace it rather than adding a second one, or every
+    # line logs twice (once plain, once JSON).
+    handler = logging.StreamHandler()
+    handler.setFormatter(_JsonFormatter())
+    root.handlers = [handler]
+
+
+access_logger = logging.getLogger("tally.access")
+
+
+async def log_requests(
+    request: Request, call_next: Callable[[Request], Awaitable[Response]]
+) -> Response:
+    start = time.perf_counter()
+    response = await call_next(request)
+    duration_ms = round((time.perf_counter() - start) * 1000, 2)
+
+    access_logger.info(
+        "request",
+        extra={
+            "extra_fields": {
+                "method": request.method,
+                "path": request.url.path,
+                "status_code": response.status_code,
+                "duration_ms": duration_ms,
+            }
+        },
+    )
+    return response

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -14,8 +14,13 @@ from src.api import (
     windfalls,
 )
 from src.core.auth import get_current_user
+from src.core.logging import configure_logging, log_requests
+
+configure_logging()
 
 app = FastAPI()
+
+app.middleware("http")(log_requests)
 
 app.include_router(accounts.router)
 app.include_router(bills.router)

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,0 +1,369 @@
+# Operations
+
+Production hardening reference for Tally: observability, backup/DR, cost, security posture,
+a deployment audit, the DNS decision, and a runbook for routine ops tasks. Written for a solo
+developer coming back after weeks-long gaps — assume you've forgotten everything below.
+
+This is the detail behind [docs/ROADMAP.md](ROADMAP.md)'s Phase 5 checklist; check there first
+for current status, then come here for the how/why.
+
+## Observability
+
+**Structured logging**: the backend logs JSON lines (`backend/src/core/logging.py`) - one
+`{"logger": "tally.access", "message": "request", "method", "path", "status_code",
+"duration_ms"}` line per request, plus any application log calls, all going to stdout, which
+Lambda ships to CloudWatch Logs automatically (`AWSLambdaBasicExecutionRole`, attached in
+`infra/modules/lambda/main.tf`). Level is `LOG_LEVEL` (default `INFO`; see
+`backend/.env.example`). JSON (not plain text) so CloudWatch Logs Insights can query fields
+directly, e.g.:
+
+```
+fields @timestamp, method, path, status_code, duration_ms
+| filter status_code >= 500
+| sort @timestamp desc
+```
+
+**What's deliberately not done**: no custom CloudWatch metrics/dashboards or alarms yet -
+every custom metric and every alarm has a per-metric cost, and at solo-developer traffic
+volumes the log-based visibility above is enough to debug an incident after the fact. If usage
+grows enough that "check the logs when something looks wrong" stops being viable, the next
+step is a couple of alarms on Lambda's free built-in metrics (`Errors`, `Duration`,
+`Throttles` - no custom metrics needed) with an SNS topic emailing you, not a dashboard.
+
+**Known gap - CloudWatch log group retention**: `AWSLambdaBasicExecutionRole` lets the Lambda
+service auto-create its log group (`/aws/lambda/tally-backend`) on first invocation, and an
+auto-created group defaults to **Never Expire** retention - logs (and their storage cost)
+accumulate forever. This wasn't fixed via Terraform in this pass: managing that log group as
+an `aws_cloudwatch_log_group` resource requires either importing the already-existing group
+into state first or Terraform's `apply` fails with "already exists". Since this session's AWS
+SSO session was expired and a fresh login is an interactive step only Ken can do, the safe fix
+is a one-time manual command rather than a Terraform change that could break the next
+`terraform-apply.yml` run:
+
+```bash
+aws logs put-retention-policy --log-group-name /aws/lambda/tally-backend --retention-in-days 30
+```
+
+Run this once (after `make aws-login`), then it's set permanently - no recurring action
+needed. Revisit bringing it under Terraform (via `terraform import`) if the log group is ever
+recreated (e.g. after a `terraform destroy`).
+
+**API Gateway access logging** is not enabled either (the REST API stage has no
+`access_log_settings`). Enabling it requires an account-level CloudWatch role
+(`aws_api_gateway_account`) which is a singleton per AWS account - adding it via Terraform
+without first checking whether one already exists (can't verify without live credentials this
+session) risks clobbering an unrelated existing setting. Lambda's own request logs (above)
+already cover per-request visibility; API Gateway access logs would mainly add gateway-level
+4xx/5xx counts that aren't currently needed. Low priority - revisit if debugging ever needs the
+API Gateway hop specifically distinguished from the Lambda's own logs.
+
+## Backup / Disaster Recovery
+
+Production Postgres is Neon (manual, not Terraform-managed - see
+[docs/ROADMAP.md](ROADMAP.md)'s "Neon: manual vs. Terraform-managed" decision). Neon's backup
+model, per [its docs](https://neon.com/docs/manage/backups):
+
+- **Instant restore / point-in-time recovery (PITR)**: Neon retains a continuous history of
+  storage changes and can restore (or branch) to any timestamp within that window, no
+  traditional backup/restore process needed. The window depends on plan:
+  - **Free plan: 6 hours**, capped at 1 GB-month of history.
+  - **Launch plan: up to 7 days** (billed per GB-month beyond the plan's included storage).
+  - **Scale plan: up to 30 days**.
+- **Manual `pg_dump`**: a standard logical backup, independent of Neon's own retention -
+  useful for an off-platform copy or before a risky migration.
+
+**Confirm which plan prod is on** (Neon console → project settings → Billing) - this
+determines the actual recovery window and is a real cost/risk tradeoff, not something to guess
+at here. A 6-hour window (Free) means an issue noticed the next morning is already
+unrecoverable via PITR; 7 days (Launch, ~$19/mo minimum) covers "came back from a long weekend
+and noticed bad data." **Flagging for Ken**: decide whether Tally's current data
+(user-entered bills/transactions, no real bank linkage - see the Privacy Policy) justifies the
+Launch plan's cost for a longer PITR window, or whether Free's 6 hours plus the manual
+`pg_dump` drill below is an acceptable risk for now.
+
+### Restore drill (do this at least once, then whenever the Neon plan changes)
+
+Neon's restore is done via **branching** - you create a new branch from a past point in time,
+verify it, then either point the app at it or copy data back. Nothing here touches the
+production branch unless you explicitly promote it.
+
+1. In the Neon console, open the `tally` project → **Branches** → **Create branch**.
+2. Choose **"From a specific time"** and pick a timestamp within the retention window (or
+   "now" for a smoke test of the mechanism itself).
+3. Once the branch is ready, grab its connection string (console → branch → Connection
+   Details) and connect with `psql` (see `docs/DEVELOPING.md`'s "Accessing the Production
+   Database" section for the connection-string shape).
+4. Verify expected data is present (e.g. `select count(*) from bills;` and spot-check a
+   recently-modified row against what you expect).
+5. Delete the drill branch when done (branches aren't free-tier-unlimited on all plans).
+
+If a real restore is ever needed: create the branch as above from the target timestamp, then
+either (a) update `TF_VAR_database_url_readwrite`/`readonly` (GitHub repo secrets
+`TALLY_DATABASE_URL_READWRITE`/`READONLY`) to point at the restored branch and redeploy, or
+(b) use the branch as a source to copy specific rows back into the primary branch via
+`pg_dump`/`pg_restore` for a targeted fix rather than a full cutover.
+
+**Off-platform backup**: no automated `pg_dump`-to-S3 export is configured. Given the low
+production data volume (solo project, no paying customers as of this writing) and Neon's PITR
+already covering the "oops" case, this wasn't added this pass to avoid another moving part
+(GitHub Actions schedule + S3 lifecycle policy + restore-tested-or-it-doesn't-count) for a risk
+that's already mitigated. Revisit if/when real user data volume makes "the only copy is Neon's
+own PITR" feel too thin.
+
+## Cost Review
+
+Estimated based on the resources in `infra/` and public pricing as of this writing - not a
+live Cost Explorer pull (this session's AWS SSO token was expired; see the Deployment Audit
+section for what that blocked). **Ken should confirm against the actual AWS Billing console
+and Neon/Auth0 dashboards** - these are estimates, not verified spend.
+
+| Resource | Free tier | Cost once past free tier |
+|---|---|---|
+| Lambda | 1M requests + 400,000 GB-s/month, **permanently free** | $0.20/M requests + $0.0000166667/GB-s - solo-dev traffic stays near $0 indefinitely |
+| API Gateway (REST) | 1M calls/month for **12 months from account creation only** | $3.50/M requests after - low volume keeps this at cents/month even off free tier |
+| CloudFront | 1TB out + 10M requests/month for 12 months | ~$0.085/GB after - a low-traffic static SPA stays well under $1/month |
+| S3 (frontend + backend buckets) | 5GB storage for 12 months | Storage here is a few MB (SPA build + one Lambda zip with versioning) - negligible either way |
+| ACM certificate | Always free | n/a |
+| CloudWatch Logs | 5GB ingestion + 5GB storage, **always free** | $0.50/GB ingested past that - see the retention-policy gap noted above, since unbounded retention is what would eventually cross this line |
+| Neon (Postgres) | Free: 0.5GB storage, ~191 compute-hours/month, 6h PITR | Launch starts ~$19/month for 7-day PITR + more storage/compute |
+| Auth0 | Free: 25,000 MAU, 1-day log retention | Paid tiers add longer log retention, custom domains, MFA - not needed at current scale |
+| Domain (Hover) | n/a | Already owned, renews annually outside AWS - not part of this cost review |
+| Route 53 | not used | n/a - see DNS decision below |
+
+**The one real free-tier cliff to watch**: API Gateway's REST API free tier is only for the
+account's first 12 months, not "always free" like Lambda and CloudWatch Logs. Once past that
+anniversary, every API call costs $3.50 per million - at solo-developer traffic this is still
+pennies, but it's the one line item that goes from $0 to non-zero on a fixed date, not with
+usage growth. **Action for Ken**: check the AWS account's creation date and note in this doc
+whether Tally's prod traffic is still inside that window.
+
+**Cost-first architecture already in place** (per `CLAUDE.md`'s philosophy, confirmed by this
+review, no changes needed): no NAT Gateway or Elastic IPs (Lambda isn't in a VPC at all - see
+the Deployment Audit's note on issue #8), no RDS (Neon instead), `PriceClass_100` on
+CloudFront (US/EU/Asia edge locations only, not the pricier global set), S3 lifecycle/versioning
+kept minimal (versioning only on the backend artifacts bucket, which needs rollback capability;
+not on the frontend bucket, which doesn't).
+
+**Recommendation**: no cost-driven changes needed right now. Revisit this table in ~6 months
+or if traffic meaningfully grows, whichever comes first - add a line to the session log when
+you do.
+
+## Security Hardening Review
+
+Changes made this pass (see the commit that shipped alongside this doc):
+
+- **Removed the Lambda execution role's `AmazonS3ReadOnlyAccess` attachment**
+  (`infra/modules/lambda/main.tf`) - account-wide read access to every S3 bucket in the
+  account, unused by the app itself (confirmed via `grep` - no `boto3`/S3 calls anywhere in
+  `backend/src`). The Lambda deployment package is fetched by AWS's own Lambda service using
+  its own permissions, not by application code, so this was pure unnecessary blast radius.
+  Only `AWSLambdaBasicExecutionRole` (CloudWatch Logs write) remains attached.
+- **Added an explicit `aws_s3_bucket_public_access_block`** to the frontend S3 bucket
+  (`infra/modules/frontend_s3/main.tf`), matching the backend artifacts bucket's existing
+  posture. The bucket policy already only grants CloudFront's service principal access
+  (scoped further by an `AWS:SourceArn` condition), which isn't "public" access in AWS's
+  sense, so this doesn't change current behavior - it's a guard against a future accidental
+  public grant, not a fix for an existing hole.
+
+Reviewed, no change made (reasoning below):
+
+- **API Gateway proxy method has `authorization = "NONE"`**
+  (`infra/modules/api_gateway/main.tf`) - intentional. Auth is enforced in the FastAPI app
+  itself (`get_current_user`, JWKS-based JWT validation against Auth0), not at the gateway
+  layer. `/api/v1/demo/*` is deliberately public (no auth at all, by design - see
+  `docs/ROADMAP.md` Phase 4.6). Adding a Lambda authorizer here would duplicate the app-layer
+  check for no real gain, and would need to special-case the demo routes anyway.
+- **CORS** (`backend/src/main.py`) only allows `localhost`/`127.0.0.1:5173` origins - correct,
+  since prod frontend and API share an origin via CloudFront's routing and never need
+  cross-origin requests in production. No wildcard, no prod domain even listed (not needed).
+- **Terraform state**: S3 backend with `encrypt = true` (`infra/backend.conf`); state bucket
+  access itself is IAM-gated (only reachable via the GitHub Actions OIDC role or Ken's own AWS
+  SSO identity) - reasonable for a single-maintainer project. No state locking table (DynamoDB)
+  configured; a concurrent `terraform apply` collision is a real but low-likelihood risk for a
+  solo developer + one CI workflow with `concurrency: group: terraform-apply-prod` already
+  serializing applies (`terraform-apply.yml`) - the concurrency group is the actual mitigation
+  here, not S3 locking.
+- **Secrets**: DB/Auth0 values reach the Lambda as plain environment variables, not AWS
+  Secrets Manager (documented tradeoff already, see `infra/README.md` and `infra/main.tf`'s
+  comments) - Secrets Manager costs $0.40/secret/month plus API calls, for a benefit (secret
+  rotation, IAM-gated read) that doesn't clearly outweigh the cost at this scale. Revisit only
+  if a compliance requirement forces it.
+- **GitHub Actions → AWS auth**: already uses OIDC (`role-to-assume` via
+  `aws-actions/configure-aws-credentials`), not long-lived access keys - no change needed,
+  this is already the secure pattern.
+
+Not reviewed live this session (blocked by the expired AWS SSO token - flagging for Ken rather
+than guessing):
+
+- Actual IAM policy documents attached to the GitHub Actions OIDC role
+  (`tally-github-actions-role` per `CLAUDE.md`) - confirm it's scoped to what
+  `terraform-apply.yml`/`deploy-frontend.yml` actually need (S3, Lambda, API Gateway,
+  CloudFront, ACM, IAM-for-its-own-role) rather than broader `AdministratorAccess`-equivalent
+  access reused from local dev convenience.
+- Auth0 tenant security settings (MFA availability, brute-force protection, anomaly
+  detection) - dashboard-only, not something this repo's code can verify or configure. Auth0's
+  free tier includes basic attack protection by default; confirm it's turned on in the
+  dashboard (Auth0 → Security → Attack Protection).
+- CloudFront/API Gateway WAF - not configured, and not recommended to add at this traffic
+  scale (WAF has a fixed monthly cost - $5/web ACL + per-rule - that isn't justified pre-
+  meaningful-traffic; revisit if abuse/scraping actually shows up in logs).
+
+## Production Deployment Audit
+
+Reconciling the original bootstrap issues against what's actually live in `infra/` and
+`.github/workflows/`:
+
+| Issue | Original scope | Actual state |
+|---|---|---|
+| #8 (Lambda + VPC + Secrets Manager) | VPC, private subnets, Secrets Manager | **Superseded** - cost-first design keeps Lambda out of a VPC entirely (no NAT Gateway cost) and passes config as plain env vars (see Security review above). Deployed via `terraform-apply.yml`, not manually. Runtime is `python3.13` (not the issue's `python3.11` - keeps current). No X-Ray tracing (not needed - CloudWatch logs cover current debugging needs; X-Ray has its own per-trace cost). |
+| #9 (API Gateway + CORS) | API Gateway with CORS configured on the gateway | **Done, differently** - `infra/modules/api_gateway/main.tf` has the `{proxy+}` → Lambda integration; CORS is handled in the FastAPI app instead of at the gateway (see Security review). API Gateway access logging is **not** enabled (see Observability's note - a real, acknowledged gap, low priority). Domain in the original issue (`tally.kenhowardpdx.com`) is stale - actual domain is `tally.kenhoward.dev`. |
+| #10 (S3 + CloudFront OAI) | S3 + OAI, public access blocked, versioning | **Done, with an upgrade** - uses OAC (Origin Access Control), the modern replacement for the now-legacy OAI. Public access block was missing on the frontend bucket until this pass (now added, see Security review); backend bucket already had it. Versioning is only on the backend artifacts bucket (needed for Lambda zip rollback), not the frontend bucket (S3 sync + CloudFront invalidation is the frontend's own "redeploy the last good build" path - see Runbook below). |
+| #12 (CloudFront + ACM) | ACM cert, CloudFront, SPA routing, compression | **Done** - `PriceClass_100`, DNS-validated ACM cert in us-east-1, `custom_error_response` blocks for SPA deep-links (403/404 → `/index.html`, a real bug fixed in an earlier session - see `docs/ROADMAP.md`'s 2026-07-12 log entry). CloudFront's default compression is on by default for compressible content types - no explicit config needed. |
+| #17 (frontend deploy script) | Deployment script | **Done, as a GitHub Action** instead of a local script - `deploy-frontend.yml` builds, syncs to S3, invalidates CloudFront, on every push to `main` touching `frontend/**`. Arguably better than a local script for a solo dev (no "did I remember to run the script" risk). |
+| #18 (backend deploy automation) | Lambda packaging + deploy script | **Done, as a GitHub Action** - `terraform-apply.yml` builds the zip (native pip install on the Linux runner, matching Lambda's `python3.13`/AL2023 runtime), stages it to S3, runs Alembic migrations, then plans/applies. **Gap**: no rollback capability beyond "revert the commit and let CI redeploy" - no Lambda versioning/aliases for instant rollback. See the Runbook's rollback procedure below for what "rollback" actually means today. |
+
+**Overall**: every issue's *intent* shipped, mostly via GitHub Actions automation rather than
+local scripts (an improvement on the original scope, and consistent with wanting deploys to
+not depend on remembering to run something locally). The two real gaps worth tracking forward
+are already captured above rather than re-listed here: API Gateway access logging
+(Observability) and no fast Lambda rollback path (Runbook, below). Both are low-severity at
+current scale.
+
+## DNS / Domain Decision
+
+**Decision: keep DNS at Hover, do not migrate to Route 53.**
+
+`tally.kenhoward.dev` currently resolves via a CNAME/ALIAS at Hover pointing at the CloudFront
+distribution's domain name - this already works today (verified in this session's E2E check
+below) and has for multiple prior sessions. Issues #13/#14 proposed moving to Route 53; the
+case for actually doing it:
+
+- **Cost**: Route 53 hosted zones are $0.50/month each, plus per-query charges past the free
+  tier - a pure added cost with no corresponding removed cost (Hover's registration fee is
+  unchanged either way; DNS hosting is a separate, additional thing you'd be paying AWS for on
+  top of what Hover already does for free as part of registration).
+- **Operational benefit**: would mainly matter if Tally needed Route 53-specific features
+  (health-check-based failover, latency-based routing, ACM DNS validation fully automated via
+  Terraform's `aws_route53_record` instead of a manual DNS step) - none of which apply at
+  Tally's current single-region, single-CloudFront-distribution scale. ACM validation already
+  happened once, manually, and doesn't need to happen again unless the certificate is replaced
+  (auto-renewal doesn't require re-validation for ACM-issued certs on the same domain).
+- **Migration risk**: nameserver cutover has a real (if small) window of DNS propagation risk
+  for zero functional gain here.
+
+**If this changes**: revisit if Tally ever needs multi-region failover, or if enough other
+domains/subdomains accumulate that centralizing DNS management in Terraform (rather than
+Hover's UI) becomes worth the $0.50/month. Until then, the manual process is: log into Hover,
+edit the CNAME for `tally` under `kenhoward.dev` if the CloudFront distribution's domain name
+ever changes (it doesn't change on its own - only on distribution recreation, which normal
+`terraform apply` updates don't trigger).
+
+`infra/README.md`'s architecture diagram previously showed a Route 53 box that was never
+actually built - fixed as part of this pass to reflect Hover instead (see the diff alongside
+this doc).
+
+## End-to-End Production Verification
+
+Verified live against `https://tally.kenhoward.dev` in-browser this session (no AWS/Neon
+credentials needed for any of this - all through the public site):
+
+- Homepage loads, renders the marketing hero + feature cards + interactive demo widget.
+- **Real API round-trip**: filled in the demo forecast form and submitted it - network log
+  confirmed `POST https://tally.kenhoward.dev/api/v1/demo/forecast` → `200`, proving the full
+  CloudFront → API Gateway → Lambda → FastAPI path is live and working end-to-end (this
+  endpoint doesn't touch Neon, so it doesn't confirm the DB hop specifically - see below).
+- `/privacy` and `/terms` both render their full real (placeholder) copy correctly.
+- Clicking **Log in** redirects to the real Auth0 tenant's hosted login page
+  (`dev-dsg2btrpxwa1gq1v.us.auth0.com`) with a working login form - confirms the Auth0
+  integration is live and correctly configured (client ID, callback URL, tenant domain).
+  Did not complete an actual login (no test credentials were entered - entering real
+  credentials isn't something this session does automatically).
+
+**Not verified this session** (would require completing a real login, which needs an actual
+account/credentials): the authenticated app shell, the consent interstitial, and any endpoint
+that hits Neon (accounts/bills/forecast/dashboard). Given `/api/v1/demo/forecast` round-tripped
+successfully through the exact same Lambda that also serves the authenticated routes, and nothing
+DB-specific in the deploy changed, this is a low-risk gap - but it's a real one. **Recommended
+for Ken**: log in for real once after reading this, confirm the consent interstitial appears
+for a fresh session and that a real account's dashboard loads with actual Neon-backed data.
+
+## Runbook
+
+### Deploying
+
+Both frontend and backend deploy automatically on push to `main`:
+
+- **Frontend** (`deploy-frontend.yml`): triggers on `frontend/**` changes. Builds, syncs to
+  S3, invalidates CloudFront (`/*`). Live within a few minutes of merge.
+- **Backend + infra** (`terraform-apply.yml`): triggers on `infra/**`, `backend/alembic/**`,
+  `backend/src/**`, or Poetry lockfile changes. Packages the Lambda zip, uploads it, runs
+  Alembic migrations against prod, then `terraform plan`/`apply`.
+- **Manual trigger**: either workflow also supports `workflow_dispatch` from the GitHub
+  Actions UI if you need to force a redeploy without a new commit (e.g. after fixing a
+  transient CI failure).
+
+### Rolling back
+
+There's no one-click rollback today (a known gap - see the Deployment Audit's #18 note).
+What actually works:
+
+- **Frontend**: `git revert` the offending commit (or check out the last-good commit) and push
+  to `main` - `deploy-frontend.yml` rebuilds and re-syncs from that ref. Since the frontend
+  bucket isn't versioned, there's no "restore the previous S3 objects directly" shortcut;
+  rebuilding from git is the actual rollback path, and it's fast (a few minutes).
+- **Backend**: same pattern - revert the commit, push, let `terraform-apply.yml` redeploy the
+  prior Lambda code. **Caveat**: if the bad deploy included an Alembic migration, reverting the
+  *code* doesn't undo the *migration* - check `backend/alembic/versions/` for whether the
+  problem commit added one, and write/run a manual `alembic downgrade` against prod if so
+  (`DATABASE_URL_READWRITE=<prod URL> poetry run alembic downgrade -1` from `backend/`, after
+  `source .secrets` or otherwise having the prod DB URL available - **treat this as a
+  production-data-affecting action, confirm the downgrade is actually safe for a schema with
+  live data before running it**).
+- **Database**: see the Backup/DR restore drill above for point-in-time recovery via Neon
+  branching, for data (not schema) problems.
+
+### Checking prod health
+
+- **Logs**: CloudWatch → Log groups → `/aws/lambda/tally-backend`. Structured JSON (see
+  Observability above) - use Logs Insights for anything beyond eyeballing recent entries.
+- **Quick smoke test**: hit `https://tally.kenhoward.dev` (frontend) and
+  `https://tally.kenhoward.dev/api/v1/demo/forecast` (POST, any small JSON body per
+  `backend/src/api/demo.py`'s schema) - both work without needing to log in, and together
+  confirm CloudFront, S3, API Gateway, and Lambda are all up.
+- **AWS access**: `make aws-login` (direct terraform/AWS CLI use) or `make aws-creds` (for
+  `act`) from `infra/` - SSO session lasts ~8 hours, re-run when it expires (this is what
+  blocked live AWS inspection during this session - see the Security/Cost sections' flagged
+  gaps).
+
+### Incident response (solo-developer scale)
+
+No on-call rotation or paging needed at this scale - this section is "what do I do if I notice
+something's wrong," not a formal incident process.
+
+1. Check CloudWatch logs for the affected Lambda first (fastest signal for a 5xx spike or
+   error pattern).
+2. If it's a bad deploy: roll back per above.
+3. If it's a Neon issue (connection errors, slow queries): check the Neon console's own
+   monitoring/status page first - it's a managed service, so an outage there isn't something
+   this app's infra can route around.
+4. If it's an Auth0 issue: check Auth0's status page
+   ([status.auth0.com](https://status.auth0.com)) - same reasoning.
+5. Document what happened and the fix in this file's session-log-equivalent (or
+   `docs/ROADMAP.md`'s session log, if it's roadmap-relevant) once resolved, so the next
+   6-week-later session has context.
+
+## API Documentation
+
+FastAPI auto-generates interactive API docs from the route definitions already in
+`backend/src/api/` - no separate doc-maintenance burden. Available at `/docs` (Swagger UI) and
+`/redoc` by FastAPI's default, mounted at the app root rather than under `/api/v1`. **Not
+reachable in prod as deployed**: the API Gateway REST API only defines a resource for
+`/api/v1/{proxy+}` (`infra/modules/api_gateway/main.tf`) - there's no resource matching a bare
+`/docs` path, so API Gateway itself would reject the request before it ever reaches the
+Lambda. Browse the docs locally instead: `poetry run uvicorn src.main:app --reload` from
+`backend/`, then open `http://localhost:8000/docs`. If prod-reachable docs are ever wanted,
+that needs either an additional API Gateway resource for `/docs`+`/openapi.json`, or mounting
+FastAPI's docs under the `/api/v1` prefix explicitly - not done here since interactive prod API
+docs aren't currently a real need (no external API consumers yet). This still satisfies the
+roadmap's "API documentation" ask without hand-maintained docs that would drift from the actual
+routes.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -512,26 +512,61 @@ per-PR preview branch) make manual Neon console clicks a recurring chore.
 
 ## Phase 5 — Production hardening (ongoing, lower priority)
 
+**Status**: first pass complete - see [docs/OPERATIONS.md](OPERATIONS.md) for the full detail
+behind every item below. Legal review and the Neon plan/PITR-window decision are called out
+below as items only Ken can close (real money/real lawyer, not something to guess at).
+
 - [ ] Legal/compliance review of the Privacy Policy and Terms and Conditions pages
       (`frontend/src/routes/privacy/`, `frontend/src/routes/terms/`) before treating them as
-      production-ready - current copy is a reasonable placeholder, not lawyer-reviewed.
-      Revisit at the same time whether signup-time Auth0 consent (option 1 in Phase 4.7's
-      note above) is worth the tenant-configuration overhead, if a stricter guarantee than
-      "consent immediately after account creation" becomes a real requirement.
-- [ ] Structured logging / basic observability within free-tier limits (#19)
-- [ ] Confirm Neon's backup/retention behavior meets expectations, plus a documented
-      restore drill / disaster-recovery path (#20)
-- [ ] Periodic cost review (matches CLAUDE.md's cost-first philosophy)
-- [ ] Security hardening review for IAM/Auth0/API/storage settings, keeping the current
-      cost-first architecture in mind (#21)
-- [ ] Production deployment audit: reconcile the older infra/bootstrap issues with the
+      production-ready - current copy is a reasonable placeholder, not lawyer-reviewed. **Not
+      done this pass** - needs an actual lawyer, not something to guess at.
+- [x] Auth0 consent-timing tradeoff (JIT provisioning happens slightly before consent capture,
+      noted in Phase 4.7 above) - **reviewed, decision: keep as documented/accepted risk, no
+      code or Auth0 tenant change**. The interstitial already blocks every app route
+      immediately after login (see Phase 4.7), so the unprotected window is only the instant
+      between JIT provisioning and the interstitial rendering - not zero, but not worth
+      customizing Auth0's hosted Universal Login (a dashboard-only, out-of-version-control
+      change with no local/CI equivalent, per Phase 4.7's original reasoning, which still
+      holds). Revisit only if a real compliance requirement forces a stricter guarantee than
+      "consent immediately after account creation."
+- [x] Structured logging / basic observability within free-tier limits (#19) - JSON structured
+      logging + per-request access log (`backend/src/core/logging.py`); CloudWatch Logs
+      Insights queryable. One known gap flagged with an exact fix command in
+      `docs/OPERATIONS.md` (Lambda log group's retention policy needs a one-time manual
+      `aws logs put-retention-policy` call - blocked this session by an expired AWS SSO token).
+- [x] Confirm Neon's backup/retention behavior meets expectations, plus a documented
+      restore drill / disaster-recovery path (#20) - documented in `docs/OPERATIONS.md`
+      (PITR windows by plan, branching-based restore drill steps). **Flagged for Ken**: confirm
+      which Neon plan prod is actually on, since that determines the real recovery window
+      (Free's 6 hours vs. Launch's 7 days) - a cost/risk tradeoff only Ken can decide.
+- [x] Periodic cost review (matches CLAUDE.md's cost-first philosophy) - `docs/OPERATIONS.md`'s
+      Cost Review table; one free-tier cliff flagged (API Gateway's 12-months-from-account-
+      creation REST API free tier, not evergreen like Lambda/CloudWatch Logs).
+- [x] Security hardening review for IAM/Auth0/API/storage settings, keeping the current
+      cost-first architecture in mind (#21) - removed the Lambda role's unused, account-wide
+      `AmazonS3ReadOnlyAccess` attachment; added a public-access-block to the frontend S3
+      bucket. Full review (what was checked, what was intentionally left as-is, what needs
+      live AWS access to finish) in `docs/OPERATIONS.md`.
+- [x] Production deployment audit: reconcile the older infra/bootstrap issues with the
       current Terraform + GitHub Actions reality, document what is already live, and split
-      any remaining gaps into smaller concrete follow-ups (#8, #9, #10, #12, #17, #18)
-- [ ] DNS/domain decision: either move DNS to Route 53 and cut over from Hover, or
-      explicitly keep DNS outside AWS and document the manual process/rollback (#13, #14)
-- [ ] End-to-end production verification across Auth0, CloudFront, API Gateway, Lambda,
-      and Neon (#22)
-- [ ] System / ops / API documentation pass, including deployment/runbook coverage (#23)
+      any remaining gaps into smaller concrete follow-ups (#8, #9, #10, #12, #17, #18) - full
+      issue-by-issue reconciliation table in `docs/OPERATIONS.md`; every issue's intent has
+      shipped (mostly via GitHub Actions automation instead of the originally-scoped local
+      scripts).
+- [x] DNS/domain decision: either move DNS to Route 53 and cut over from Hover, or
+      explicitly keep DNS outside AWS and document the manual process/rollback (#13, #14) -
+      **decision: keep DNS at Hover**, no Route 53 migration. Reasoning (pure added
+      $0.50/month cost, no feature Tally needs at this scale) in `docs/OPERATIONS.md`.
+- [x] End-to-end production verification across Auth0, CloudFront, API Gateway, Lambda,
+      and Neon (#22) - verified live in-browser this session: homepage, a real demo-forecast
+      API round-trip (CloudFront → API Gateway → Lambda → 200), both legal pages, and the
+      Auth0 hosted-login redirect. **Not verified**: an actual authenticated login and any
+      Neon-backed route (would require real credentials) - flagged for Ken to spot-check once.
+- [x] System / ops / API documentation pass, including deployment/runbook coverage (#23) -
+      new `docs/OPERATIONS.md` covers all of the above plus a deploy/rollback/incident-response
+      runbook; `infra/README.md`'s stale architecture diagram (showed a Route 53 box that was
+      never built) and inaccurate security claims (claimed Secrets Manager and least-privilege
+      IAM before this session's actual fixes) corrected to match reality.
 
 ## Legacy GitHub Project issue crosswalk
 
@@ -697,3 +732,29 @@ session (or a fresh Claude Code instance) orient in under a minute.
   Verified end-to-end in-browser: interstitial blocks every (app) route until accepted,
   acceptance persists across reload, footer/legal pages render correctly down to 375px.
   Next: Phase 5, or any newly-discovered polish item.
+- 2026-07-13: Phase 5 (production hardening) first pass, written up in full in the new
+  `docs/OPERATIONS.md`. Shipped: JSON structured logging + a per-request access-log middleware
+  (`backend/src/core/logging.py`); removed the Lambda role's unused, account-wide
+  `AmazonS3ReadOnlyAccess` IAM attachment (confirmed via grep - the app never calls S3 itself);
+  added a public-access-block to the frontend S3 bucket to match the backend bucket's existing
+  posture; cleaned up `main.tf`'s dead commented-out module stubs; fixed `infra/README.md`'s
+  stale architecture diagram (it showed a Route 53 box that was never actually built - DNS has
+  always been Hover) and inaccurate security claims (it claimed Secrets Manager and
+  least-privilege IAM before today's actual fixes). Decided and documented: keep DNS at Hover
+  (no Route 53 migration - pure added cost, no feature Tally needs at this scale), and keep the
+  Auth0 consent-timing tradeoff from Phase 4.7 as an accepted risk rather than customizing
+  Auth0's hosted login (still a dashboard-only, out-of-repo change with no local/CI
+  equivalent). Verified prod end-to-end in-browser: homepage, a real demo-forecast API
+  round-trip (CloudFront → API Gateway → Lambda → 200), both legal pages, and the Auth0 hosted
+  login redirect - did not complete an actual login (no test credentials used). Production
+  deployment audit reconciled every original bootstrap issue (#8-10, #12, #17, #18) against
+  current reality in a table in `docs/OPERATIONS.md` - all shipped, mostly via GitHub Actions
+  automation instead of the originally-scoped local scripts. **Blocked this session**: the
+  local AWS SSO token was expired and refreshing it needs an interactive browser login only Ken
+  can do, so anything requiring live AWS/Neon credentials was documented as a flagged follow-up
+  rather than guessed at - notably the CloudWatch log group retention fix (exact command
+  provided), confirming which Neon plan prod is on (determines the real PITR window), the
+  legal/compliance review of the Privacy Policy and Terms pages, and a live IAM policy review
+  of the GitHub Actions OIDC role. Next: whatever Ken decides on the flagged items above, or any
+  newly-discovered polish item - Phase 5 stays open/ongoing per its own header rather than ever
+  being "complete."

--- a/infra/README.md
+++ b/infra/README.md
@@ -6,15 +6,18 @@ This directory contains the Terraform infrastructure as code for deploying Tally
 
 ```mermaid
 graph TB
+    subgraph DNS["DNS (outside AWS)"]
+        Hover["Hover<br/>CNAME: tally.kenhoward.dev"]
+    end
+
     subgraph AWS["AWS Cloud"]
-        subgraph DNS["DNS & CDN Layer"]
-            R53["Route 53<br/>tally.kenhoward.dev"]
+        subgraph CDNLayer["CDN Layer"]
             CF["CloudFront Distribution<br/>(CDN + SSL/TLS)"]
             ACM["ACM Certificate<br/>(SSL/TLS)"]
         end
 
         subgraph Frontend["Frontend Layer"]
-            S3["S3 Bucket<br/>Static Website Hosting<br/>(Svelte App)"]
+            S3["S3 Bucket<br/>OAC-protected origin<br/>(Svelte App)"]
         end
 
         subgraph API["API Layer"]
@@ -28,15 +31,23 @@ graph TB
     User["User Browser"]
     Auth0["Auth0<br/>Authentication Service"]
 
-    User --> R53
+    User --> Hover
     User <--> Auth0
-    R53 --> CF
+    Hover --> CF
     CF --> S3
-    User --> APIGW
+    CF --> APIGW
     APIGW --> Lambda
     Lambda --> Auth0
     Lambda --> Neon
 ```
+
+DNS is deliberately kept at Hover rather than migrated to Route 53 - see
+[docs/OPERATIONS.md](../docs/OPERATIONS.md)'s "DNS / Domain Decision" section for the reasoning
+(no Route 53-specific feature is needed at this scale, and it's a pure added $0.50/month for no
+operational gain). The frontend is only reachable through CloudFront (an Origin Access Control,
+not the S3 website endpoint - the `aws_s3_bucket_website_configuration` resource in
+`modules/frontend_s3/` is unused dead weight from an earlier iteration, kept only because
+removing it isn't worth the risk of being wrong about it being truly unused).
 
 Connection strings and Auth0 values reach the Lambda as plain environment variables
 (`TF_VAR_database_url_readwrite`/`readonly`, `TF_VAR_auth0_domain`/`audience` — see
@@ -148,9 +159,9 @@ The infrastructure is organized into reusable modules:
 
 ### Module Status
 
-All modules above except `auth0` are implemented and wired up in `main.tf`. Two stub blocks
-remain commented out at the bottom of `main.tf` (a duplicate `acm` and an `auth0` module call)
-— safe to ignore or clean up, not part of the active configuration.
+All modules above except `auth0` are implemented and wired up in `main.tf`. (The dead
+commented-out duplicate `acm`/`auth0` module stubs previously here were removed in the Phase 5
+cleanup - `main.tf` now only contains active configuration.)
 
 ## Development Workflow
 
@@ -272,9 +283,17 @@ make check-aws
 ## Security Considerations
 
 - **Credentials**: Never commit `.aws-credentials` file (included in `.gitignore`)
-- **State Files**: Remote state is encrypted and access-controlled
-- **IAM**: Uses least-privilege access patterns
-- **Secrets**: Sensitive data stored in AWS Secrets Manager
+- **State Files**: Remote state is encrypted (`infra/backend.conf`'s `encrypt = true`) and
+  reachable only via the GitHub Actions OIDC role or Ken's own AWS SSO identity
+- **IAM**: the Lambda execution role carries only `AWSLambdaBasicExecutionRole` (CloudWatch
+  Logs write) - an unused, account-wide `AmazonS3ReadOnlyAccess` attachment was removed in the
+  Phase 5 security review (see `docs/OPERATIONS.md`)
+- **Secrets**: DB/Auth0 values reach the Lambda as plain environment variables, not AWS
+  Secrets Manager - a deliberate cost tradeoff (Secrets Manager is $0.40/secret/month plus API
+  calls), documented in `docs/OPERATIONS.md`'s security review, not an oversight
+
+See [docs/OPERATIONS.md](../docs/OPERATIONS.md) for the full Phase 5 security hardening
+review, cost review, and production deployment audit.
 
 ## Contributing
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -113,14 +113,3 @@ module "api_gateway" {
   api_name            = "tally-api"
   aws_region          = var.aws_region
 }
-
-# module "acm" {
-#   source = "./modules/acm"
-#   # Add acm module variables here
-# }
-
-
-# module "auth0" {
-#   source = "./modules/auth0"
-#   # Add auth0 module variables here
-# }

--- a/infra/modules/frontend_s3/main.tf
+++ b/infra/modules/frontend_s3/main.tf
@@ -4,6 +4,20 @@ resource "aws_s3_bucket" "frontend" {
   tags          = var.tags
 }
 
+# Belt-and-suspenders alongside the SourceArn-scoped bucket policy below: the
+# policy only ever grants CloudFront's service principal access (not "public"
+# in AWS's sense, so Block Public Access doesn't interfere with it), but an
+# explicit block still guards against a future accidental public ACL/policy
+# on this bucket. Matches backend_s3's posture (see modules/backend_s3/main.tf).
+resource "aws_s3_bucket_public_access_block" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
 
 resource "aws_s3_bucket_website_configuration" "frontend" {
   bucket = aws_s3_bucket.frontend.id

--- a/infra/modules/lambda/main.tf
+++ b/infra/modules/lambda/main.tf
@@ -14,16 +14,15 @@ resource "aws_iam_role" "lambda_exec" {
   })
 }
 
-# Attach AWS managed policies for Lambda execution and S3 access
+# CloudWatch Logs write access only. The Lambda deployment package is fetched
+# by AWS's own Lambda service (s3_bucket/s3_key above) using its own
+# infrastructure permissions, not by code running inside the function - the
+# app itself never calls the S3 API (no boto3/S3 usage in backend/src), so the
+# account-wide AmazonS3ReadOnlyAccess this previously carried was unused,
+# unnecessary access to every bucket in the account (Phase 5 security review).
 resource "aws_iam_role_policy_attachment" "lambda_basic_execution" {
   role       = aws_iam_role.lambda_exec.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-}
-
-
-resource "aws_iam_role_policy_attachment" "lambda_s3_read" {
-  role       = aws_iam_role.lambda_exec.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
 }
 
 


### PR DESCRIPTION
## Summary

First pass at Phase 5 (production hardening) from `docs/ROADMAP.md`, plus the Auth0
consent-timing follow-up noted in Phase 4.7. Full detail in the new
[`docs/OPERATIONS.md`](docs/OPERATIONS.md) — this description is the short version.

**Code changes:**
- Backend: JSON structured logging + a per-request access-log middleware
  (`backend/src/core/logging.py`) — CloudWatch Logs Insights can now query
  `method`/`path`/`status_code`/`duration_ms` directly instead of regexing plain text.
- Infra: removed the Lambda execution role's `AmazonS3ReadOnlyAccess` attachment — unused,
  account-wide S3 read access (confirmed via grep: no boto3/S3 calls anywhere in
  `backend/src`). Added an explicit public-access-block to the frontend S3 bucket, matching
  the backend artifacts bucket's existing posture. Cleaned up `main.tf`'s dead commented-out
  module stubs.
- Docs: fixed `infra/README.md`'s stale architecture diagram (showed a Route 53 box that was
  never actually built — DNS has always been Hover) and inaccurate security claims (claimed
  Secrets Manager + least-privilege IAM before this PR's actual fixes).

**Decisions made and documented (not code changes):**
- **Keep DNS at Hover** — no Route 53 migration. Pure added $0.50/month cost, no feature
  Tally needs at its current single-region scale.
- **Auth0 consent-timing tradeoff — accepted as-is.** JIT user provisioning happens an instant
  before the consent interstitial renders; customizing Auth0's hosted Universal Login to gate
  signup itself would be a dashboard-only change with no local-dev or CI equivalent (per Phase
  4.7's original reasoning, which still holds).

**Verified end-to-end against the live site** (`https://tally.kenhoward.dev`), no AWS/Neon
credentials needed: homepage renders, a real demo-forecast API round-trip succeeded
(`POST /api/v1/demo/forecast` → 200 through CloudFront → API Gateway → Lambda), both legal
pages render, and the login button correctly redirects to the real Auth0 tenant's hosted login
page. Did not complete an actual login (no test credentials entered).

## Flagged for Ken — needs a real decision or live credentials this session didn't have

- **Neon plan / PITR window**: confirm which plan prod is actually on (Free = 6h restore
  window, Launch = 7 days for ~$19/mo) — a real cost/risk tradeoff, documented in
  `docs/OPERATIONS.md`'s Backup/DR section.
- **CloudWatch log group retention**: the Lambda's auto-created log group defaults to "Never
  Expire." Exact one-time fix command is in `docs/OPERATIONS.md`'s Observability section —
  not done via Terraform because the group already exists and importing it needs a live AWS
  session (this session's SSO token was expired).
- **Legal/compliance review** of the Privacy Policy and Terms pages — still just a reasonable
  placeholder, not lawyer-reviewed.
- **Live IAM review** of the GitHub Actions OIDC role's actual policy document — couldn't
  inspect it live this session (expired AWS SSO token); flagged in `docs/OPERATIONS.md`'s
  Security review as not-yet-verified.

## Test plan

- [x] `poetry run pytest` — 137 passed
- [x] `terraform validate` + `terraform fmt -check -recursive` — clean
- [x] Live browser verification against `https://tally.kenhoward.dev` (see above)
- [ ] Ken: run the flagged CloudWatch retention-policy command once AWS SSO is refreshed
- [ ] Ken: confirm Neon's plan/PITR window

🤖 Generated with [Claude Code](https://claude.com/claude-code)
