### PR TITLE
Bridge Cycle History and Activity views on the bill history page

### DIFF
--- a/backend/src/api/bills.py
+++ b/backend/src/api/bills.py
@@ -13,7 +13,7 @@ from src.forecast import ForecastBill, ForecastCycleOverride, build_bill_history
 from src.forecast.bill import validate_recurrence_config
 from src.models import BankAccount, Bill, BillEvent, CycleOverride, CycleType, RecurrenceType, User
 from src.schemas.bill import BillCreate, BillRead, BillUpdate
-from src.schemas.bill_event import BillEventListResponse
+from src.schemas.bill_event import BillEventCycleCount, BillEventCycleCountsResponse, BillEventListResponse
 from src.schemas.bill_history import BillHistoryEntry, BillHistoryResponse
 
 router = APIRouter(prefix="/api/v1/accounts/{account_id}/bills", tags=["bills"])
@@ -230,21 +230,52 @@ async def get_bill_history(
 async def get_bill_events(
     db: AsyncSession = Depends(get_db),
     bill: Bill = Depends(_get_owned_bill),
+    cycle_start_date: date | None = None,
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
 ) -> BillEventListResponse:
-    count_result = await db.execute(
-        select(func.count()).select_from(BillEvent).where(BillEvent.bill_id == bill.id)
-    )
+    # cycle_start_date narrows to just that cycle's events (bill-level
+    # events like "created" have no cycle_start_date and are excluded) -
+    # used by the Cycle History table's per-row "N changes" expansion, so it
+    # doesn't have to fetch and filter the bill's entire activity log
+    # client-side.
+    filters = [BillEvent.bill_id == bill.id]
+    if cycle_start_date is not None:
+        filters.append(BillEvent.cycle_start_date == cycle_start_date)
+
+    count_result = await db.execute(select(func.count()).select_from(BillEvent).where(*filters))
     total = count_result.scalar_one()
     result = await db.execute(
         select(BillEvent)
-        .where(BillEvent.bill_id == bill.id)
+        .where(*filters)
         .order_by(BillEvent.created_at.desc(), BillEvent.id.desc())
         .offset(offset)
         .limit(limit)
     )
     return BillEventListResponse(bill_id=bill.id, total=total, events=list(result.scalars().all()))
+
+
+@router.get("/{bill_id}/events/cycle-counts", response_model=BillEventCycleCountsResponse)
+async def get_bill_event_cycle_counts(
+    db: AsyncSession = Depends(get_db),
+    bill: Bill = Depends(_get_owned_bill),
+) -> BillEventCycleCountsResponse:
+    """How many events exist per cycle, across the bill's whole history - lets
+    the Cycle History table show a "N changes" affordance on every row in one
+    request instead of querying per row. Grouping raw event rows needs none
+    of get_bill_history's cycle-boundary/anchor logic: each cycle-scoped
+    event already recorded the exact cycle_start_date its override used.
+    """
+    result = await db.execute(
+        select(BillEvent.cycle_start_date, func.count())
+        .where(BillEvent.bill_id == bill.id, BillEvent.cycle_start_date.is_not(None))
+        .group_by(BillEvent.cycle_start_date)
+    )
+    counts = [
+        BillEventCycleCount(cycle_start_date=cycle_start_date, count=count)
+        for cycle_start_date, count in result.all()
+    ]
+    return BillEventCycleCountsResponse(bill_id=bill.id, counts=counts)
 
 
 @router.delete("/{bill_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/src/schemas/bill_event.py
+++ b/backend/src/schemas/bill_event.py
@@ -20,3 +20,13 @@ class BillEventListResponse(BaseModel):
     bill_id: int
     total: int
     events: list[BillEventRead]
+
+
+class BillEventCycleCount(BaseModel):
+    cycle_start_date: date
+    count: int
+
+
+class BillEventCycleCountsResponse(BaseModel):
+    bill_id: int
+    counts: list[BillEventCycleCount]

--- a/backend/tests/test_bill_events_api.py
+++ b/backend/tests/test_bill_events_api.py
@@ -247,3 +247,92 @@ async def test_events_scoped_to_owning_user(client: AsyncClient):
     _login_as("auth0|someone-else")
     res = await client.get(f"/api/v1/accounts/{account['id']}/bills/{bill['id']}/events")
     assert res.status_code == 404
+
+
+async def test_events_filtered_by_cycle_start_date_excludes_other_cycles_and_bill_level(
+    client: AsyncClient,
+):
+    account = await _create_account(client)
+    bill = await _create_bill(client, account["id"])
+    # A bill-level event (no cycle_start_date) plus two different cycles'
+    # worth of cycle-scoped events.
+    await client.patch(
+        f"/api/v1/accounts/{account['id']}/bills/{bill['id']}", json={"amount_cents": 160000}
+    )
+    await client.put(
+        "/api/v1/cycle-overrides",
+        json={
+            "account_id": account["id"],
+            "bill_id": bill["id"],
+            "cycle_start_date": "2026-01-01",
+            "completed": True,
+        },
+    )
+    await client.put(
+        "/api/v1/cycle-overrides",
+        json={
+            "account_id": account["id"],
+            "bill_id": bill["id"],
+            "cycle_start_date": "2026-02-01",
+            "completed": True,
+        },
+    )
+
+    res = await client.get(
+        f"/api/v1/accounts/{account['id']}/bills/{bill['id']}/events"
+        "?cycle_start_date=2026-01-01"
+    )
+    body = res.json()
+    assert body["total"] == 1
+    assert body["events"][0]["event_type"] == "cycle_marked_paid"
+    assert body["events"][0]["cycle_start_date"] == "2026-01-01"
+
+
+async def test_cycle_counts_groups_by_cycle_and_excludes_bill_level_events(
+    client: AsyncClient,
+):
+    account = await _create_account(client)
+    bill = await _create_bill(client, account["id"])
+    # Bill-level events - must not appear in any cycle's count.
+    await client.patch(
+        f"/api/v1/accounts/{account['id']}/bills/{bill['id']}", json={"notes": "hi"}
+    )
+    # Two events in the same cycle (paid, then a note).
+    await client.put(
+        "/api/v1/cycle-overrides",
+        json={
+            "account_id": account["id"],
+            "bill_id": bill["id"],
+            "cycle_start_date": "2026-01-01",
+            "completed": True,
+            "notes": "paid via check",
+        },
+    )
+    # One event in a different cycle.
+    await client.put(
+        "/api/v1/cycle-overrides",
+        json={
+            "account_id": account["id"],
+            "bill_id": bill["id"],
+            "cycle_start_date": "2026-02-01",
+            "completed": True,
+        },
+    )
+
+    res = await client.get(
+        f"/api/v1/accounts/{account['id']}/bills/{bill['id']}/events/cycle-counts"
+    )
+    assert res.status_code == 200
+    counts = {c["cycle_start_date"]: c["count"] for c in res.json()["counts"]}
+    assert counts == {"2026-01-01": 2, "2026-02-01": 1}
+
+
+async def test_cycle_counts_scoped_to_owning_user(client: AsyncClient):
+    account = await _create_account(client)
+    bill = await _create_bill(client, account["id"])
+
+    _login_as("auth0|someone-else")
+    res = await client.get(
+        f"/api/v1/accounts/{account['id']}/bills/{bill['id']}/events/cycle-counts"
+    )
+    assert res.status_code == 404

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -391,6 +391,17 @@ per-PR preview branch) make manual Neon console clicks a recurring chore.
       to bills only (not windfalls) — the ask was specifically about bill audit history.
       Frontend: an "Activity" timeline on the existing bill history page, alongside the
       cycle-by-cycle table.
+- [x] 3.13 Bridge Cycle History and Activity instead of merging them - they're different
+      shapes (one row per cycle occurrence showing current state, vs. one row per change
+      including superseded intermediate ones) so a full merge would lose one or the other.
+      Each Cycle History row now shows an "N changes" affordance when that cycle has
+      activity, expanding inline to the same event/diff rendering the Activity tab uses,
+      scoped to just that `cycle_start_date`. Backend: `cycle_start_date` filter added to
+      `GET .../bills/{bill_id}/events`, plus a new `GET .../bills/{bill_id}/events/cycle-counts`
+      (grouped counts per cycle, one request covers every visible row rather than querying
+      per row) — both in `backend/src/api/bills.py`. No cycle-boundary computation needed
+      for the counts endpoint since each cycle-scoped event already recorded the exact
+      `cycle_start_date` its override used.
 
 
 ## Phase 4 — Multi-account dashboard & polish
@@ -829,3 +840,18 @@ session (or a fresh Claude Code instance) orient in under a minute.
   of the GitHub Actions OIDC role. Next: whatever Ken decides on the flagged items above, or any
   newly-discovered polish item - Phase 5 stays open/ongoing per its own header rather than ever
   being "complete."
+- 2026-07-13: Shipped 3.13, bridging Cycle History and Activity after a design discussion
+  about whether the two views should just be one - concluded no (different
+  cardinality: one row per cycle vs. one row per change, plus bill-level events that
+  aren't tied to any cycle at all), but a lightweight bridge was worth building. Each
+  Cycle History row now shows an "N changes" link when that cycle has activity,
+  expanding inline via a lazily-fetched, cycle-scoped slice of the same event data the
+  Activity tab renders (`cycle_start_date` filter on `GET .../bills/{bill_id}/events`,
+  plus a new grouped-counts endpoint so the whole table's badges come from one request
+  instead of one per row). 151 backend tests pass (3 new), `svelte-check` and 23
+  frontend tests pass. Verified end-to-end in-browser: created a bill whose due date
+  landed in the account's first forecast cycle, applied a paid+amount+notes cycle
+  override via the API, confirmed the "3 changes" badge appeared, expanded to show all
+  three diffed events, and collapsed again without refetching. Next: Phase 5's
+  remaining items, the local-dev/test DB isolation footgun, or any newly-discovered
+  polish item.

--- a/frontend/src/lib/api/bills.ts
+++ b/frontend/src/lib/api/bills.ts
@@ -1,5 +1,11 @@
 import { apiFetch, apiJson, ApiError } from '$lib/api';
-import type { Bill, BillEventListResponse, BillHistoryResponse, BillInput } from '$lib/api/types';
+import type {
+	Bill,
+	BillEventCycleCountsResponse,
+	BillEventListResponse,
+	BillHistoryResponse,
+	BillInput
+} from '$lib/api/types';
 
 export function listBills(accountId: number): Promise<Bill[]> {
 	return apiJson(`/api/v1/accounts/${accountId}/bills`);
@@ -42,13 +48,21 @@ export function getBillHistory(
 export function getBillEvents(
 	accountId: number,
 	billId: number,
-	params: { limit?: number; offset?: number } = {}
+	params: { limit?: number; offset?: number; cycle_start_date?: string } = {}
 ): Promise<BillEventListResponse> {
 	const query = new URLSearchParams();
 	if (params.limit != null) query.set('limit', String(params.limit));
 	if (params.offset != null) query.set('offset', String(params.offset));
+	if (params.cycle_start_date != null) query.set('cycle_start_date', params.cycle_start_date);
 	const qs = query.toString();
 	return apiJson(`/api/v1/accounts/${accountId}/bills/${billId}/events${qs ? `?${qs}` : ''}`);
+}
+
+export function getBillEventCycleCounts(
+	accountId: number,
+	billId: number
+): Promise<BillEventCycleCountsResponse> {
+	return apiJson(`/api/v1/accounts/${accountId}/bills/${billId}/events/cycle-counts`);
 }
 
 export async function exportBillsCsv(accountId: number): Promise<Blob> {

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -184,6 +184,16 @@ export interface BillEventListResponse {
 	events: BillEvent[];
 }
 
+export interface BillEventCycleCount {
+	cycle_start_date: string;
+	count: number;
+}
+
+export interface BillEventCycleCountsResponse {
+	bill_id: number;
+	counts: BillEventCycleCount[];
+}
+
 export interface BillHistoryResponse {
 	bill_id: number;
 	total: number;

--- a/frontend/src/routes/(app)/accounts/[id]/bills/[billId]/history/+page.svelte
+++ b/frontend/src/routes/(app)/accounts/[id]/bills/[billId]/history/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/stores';
-	import { getBillEvents, getBillHistory, listBills } from '$lib/api/bills';
+	import { getBillEventCycleCounts, getBillEvents, getBillHistory, listBills } from '$lib/api/bills';
 	import type { Bill, BillEvent, BillHistoryEntry } from '$lib/api/types';
 	import { describeBillEvent } from '$lib/billEvents';
 	import Button from '$lib/components/Button.svelte';
@@ -26,6 +26,19 @@
 	let eventsTotal = $state(0);
 	let eventsLoadingMore = $state(false);
 
+	// How many activity events exist per cycle_start_date, across the bill's
+	// whole history (not just the currently-loaded page of cycle entries) -
+	// fetched once up front so every row's "N changes" affordance is free.
+	let cycleCounts = $state<Record<string, number>>({});
+	// Keyed by the same row key the #each below uses (due_date + cycle_start_date),
+	// since a bill that recurs more than once within a single cycle produces
+	// multiple rows sharing one cycle_start_date - each expands independently.
+	let expandedRows = $state<Record<string, boolean>>({});
+	// Keyed by cycle_start_date and shared across same-cycle rows, so
+	// expanding a second row for an already-fetched cycle doesn't refetch.
+	let cycleEvents = $state<Record<string, BillEvent[]>>({});
+	let cycleEventsLoading = $state<Record<string, boolean>>({});
+
 	let error = $state<string | null>(null);
 
 	function formatAmount(cents: number): string {
@@ -43,20 +56,44 @@
 		loading = true;
 		error = null;
 		try {
-			const [bills, history, eventList] = await Promise.all([
+			const [bills, history, eventList, cycleCountsResponse] = await Promise.all([
 				listBills(accountId),
 				getBillHistory(accountId, billId, { limit: PAGE_SIZE, offset: 0 }),
-				getBillEvents(accountId, billId, { limit: PAGE_SIZE, offset: 0 })
+				getBillEvents(accountId, billId, { limit: PAGE_SIZE, offset: 0 }),
+				getBillEventCycleCounts(accountId, billId)
 			]);
 			bill = bills.find((b) => b.id === billId) ?? null;
 			entries = history.entries;
 			total = history.total;
 			events = eventList.events;
 			eventsTotal = eventList.total;
+			cycleCounts = Object.fromEntries(
+				cycleCountsResponse.counts.map((c) => [c.cycle_start_date, c.count])
+			);
 		} catch (err) {
 			error = err instanceof Error ? err.message : String(err);
 		} finally {
 			loading = false;
+		}
+	}
+
+	async function toggleRowExpansion(entry: BillHistoryEntry) {
+		const rowKey = entry.due_date + entry.cycle_start_date;
+		const nowExpanded = !expandedRows[rowKey];
+		expandedRows = { ...expandedRows, [rowKey]: nowExpanded };
+		if (!nowExpanded || cycleEvents[entry.cycle_start_date]) return;
+
+		cycleEventsLoading = { ...cycleEventsLoading, [entry.cycle_start_date]: true };
+		try {
+			const res = await getBillEvents(accountId, billId, {
+				cycle_start_date: entry.cycle_start_date,
+				limit: 200
+			});
+			cycleEvents = { ...cycleEvents, [entry.cycle_start_date]: res.events };
+		} catch (err) {
+			error = err instanceof Error ? err.message : String(err);
+		} finally {
+			cycleEventsLoading = { ...cycleEventsLoading, [entry.cycle_start_date]: false };
 		}
 	}
 
@@ -148,10 +185,13 @@
 							<th class="px-4 py-2 text-right font-medium">Variance</th>
 							<th class="px-4 py-2 font-medium">Paid</th>
 							<th class="px-4 py-2 font-medium">Notes</th>
+							<th class="px-4 py-2 font-medium">Activity</th>
 						</tr>
 					</thead>
 					<tbody>
 						{#each entries as entry (entry.due_date + entry.cycle_start_date)}
+							{@const rowKey = entry.due_date + entry.cycle_start_date}
+							{@const count = cycleCounts[entry.cycle_start_date] ?? 0}
 							<tr class="border-b border-slate-100 text-sm last:border-0">
 								<td class="px-4 py-2">{entry.due_date}</td>
 								<td class="px-4 py-2 text-slate-500">
@@ -180,7 +220,48 @@
 									{/if}
 								</td>
 								<td class="px-4 py-2 text-slate-600">{entry.notes ?? ''}</td>
+								<td class="px-4 py-2">
+									{#if count > 0}
+										<button
+											class="text-xs text-primary underline"
+											onclick={() => toggleRowExpansion(entry)}
+										>
+											{count} change{count === 1 ? '' : 's'}
+											{expandedRows[rowKey] ? '▴' : '▾'}
+										</button>
+									{:else}
+										<span class="text-xs text-slate-400">-</span>
+									{/if}
+								</td>
 							</tr>
+							{#if expandedRows[rowKey]}
+								<tr class="border-b border-slate-100 bg-slate-50 text-xs">
+									<td class="px-4 py-3" colspan="8">
+										{#if cycleEventsLoading[entry.cycle_start_date]}
+											<p class="text-slate-500">Loading…</p>
+										{:else}
+											<ul class="space-y-2">
+												{#each cycleEvents[entry.cycle_start_date] ?? [] as event (event.id)}
+													{@const described = describeBillEvent(event, formatAmount)}
+													<li>
+														<div class="flex flex-wrap items-baseline justify-between gap-x-4">
+															<span class="font-medium text-text">{described.label}</span>
+															<span class="text-slate-500">{formatTimestamp(event.created_at)}</span>
+														</div>
+														{#if described.details.length}
+															<ul class="mt-0.5 space-y-0.5 text-slate-600">
+																{#each described.details as detail (detail)}
+																	<li>{detail}</li>
+																{/each}
+															</ul>
+														{/if}
+													</li>
+												{/each}
+											</ul>
+										{/if}
+									</td>
+								</tr>
+							{/if}
 						{/each}
 					</tbody>
 				</Table>


### PR DESCRIPTION
## Summary

Follow-up to #99 (already merged) — after a design discussion about whether "Cycle History" (forecasted-vs-actual per cycle) and "Activity" (the append-only event log) should be merged into one view. Concluded no: they're different shapes (one row per cycle vs. one row per change, plus bill-level events with no cycle at all), so a full merge would lose one or the other. Built a lightweight bridge instead:

- Each Cycle History row now shows an **"N changes"** link when that cycle has activity, expanding inline to the same event/diff rendering the Activity tab uses — scoped to just that cycle.
- Backend: `cycle_start_date` filter added to `GET .../bills/{bill_id}/events`, plus a new `GET .../bills/{bill_id}/events/cycle-counts` (grouped counts per cycle) so the whole table's badges load in one request instead of one per row.

Rebased onto current `main` (which already includes #98's Phase 5 hardening work, merged in parallel) — no conflicts in the actual code, only in `docs/ROADMAP.md`'s session log, resolved by keeping both entries.

## Test plan

- [x] `poetry run pytest` — 151 backend tests pass (3 new)
- [x] `yarn check` (svelte-check) — 0 errors/warnings
- [x] `yarn test` — 23 frontend tests pass
- [x] Manual end-to-end browser verification (dev auth bypass + Playwright): created a bill whose due date landed in the account's first forecast cycle, applied a paid+amount+notes cycle override, confirmed the "3 changes" badge appeared, expanded to show all three diffed events, and collapsed again without refetching

🤖 Generated with [Claude Code](https://claude.com/claude-code)
