### PR TITLE
Usage analytics: activity tracking + local reporting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Tally Project Makefile
 # This Makefile provides common development tasks and GitHub Actions testing
 
-.PHONY: help github_workflow_terraform-pr github_workflow_ci aws-login aws-creds clean-terraform
+.PHONY: help github_workflow_terraform-pr github_workflow_ci aws-login aws-creds clean-terraform analytics-report
 
 # Default target
 help: ## Show this help message
@@ -96,3 +96,8 @@ uninstall-git-hooks: ## Remove git hooks
 clean-terraform: ## Remove Terraform local state and cache
 	rm -rf infra/.terraform infra/.terraform.lock.hcl infra/backend.conf infra/plan.txt infra/tfplan
 	echo "Terraform local state and cache cleaned."
+
+# Analytics
+analytics-report: ## Print local usage-metrics summary (MAU/DAU/stale accounts, see docs/ANALYTICS.md)
+	@[ -f .secrets ] || { echo "Error: .secrets file required (see .secrets.example)"; exit 1; }
+	@set -a && . ./.secrets && set +a && poetry -C backend run python scripts/analytics/report.py

--- a/backend/alembic/versions/937249cdc4e0_add_user_activity_tracking.py
+++ b/backend/alembic/versions/937249cdc4e0_add_user_activity_tracking.py
@@ -1,0 +1,51 @@
+"""add user activity tracking
+
+Revision ID: 937249cdc4e0
+Revises: c889d199265f
+Create Date: 2026-07-13 10:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '937249cdc4e0'
+down_revision: Union[str, Sequence[str], None] = 'c889d199265f'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column('users', sa.Column('last_active_at', sa.DateTime(timezone=True), nullable=True))
+
+    op.create_table(
+        'user_daily_activity',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.Column('activity_date', sa.Date(), nullable=False),
+        sa.Column(
+            'created_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('user_id', 'activity_date', name='uq_user_daily_activity_user_date'),
+    )
+    op.create_index(
+        op.f('ix_user_daily_activity_user_id'), 'user_daily_activity', ['user_id'], unique=False
+    )
+    op.create_index(
+        'ix_user_daily_activity_activity_date', 'user_daily_activity', ['activity_date'],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index('ix_user_daily_activity_activity_date', table_name='user_daily_activity')
+    op.drop_index(op.f('ix_user_daily_activity_user_id'), table_name='user_daily_activity')
+    op.drop_table('user_daily_activity')
+    op.drop_column('users', 'last_active_at')

--- a/backend/src/api/deps.py
+++ b/backend/src/api/deps.py
@@ -1,13 +1,35 @@
-from fastapi import Depends, HTTPException, status
+from datetime import datetime, timedelta, timezone
+
+from fastapi import Depends, HTTPException, Request, status
 from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.core.auth import get_current_user
 from src.core.database import get_db
-from src.models import BankAccount, User
+from src.models import BankAccount, User, UserDailyActivity
+
+# Throttle for last_active_at/user_daily_activity writes - avoids a write on
+# every single authenticated request while still giving MAU/DAU/stale-account
+# queries hour-granularity freshness.
+_ACTIVITY_THROTTLE = timedelta(hours=1)
+
+
+async def _record_activity(user: User, db: AsyncSession) -> None:
+    now = datetime.now(timezone.utc)
+    if user.last_active_at is not None and now - user.last_active_at < _ACTIVITY_THROTTLE:
+        return
+    user.last_active_at = now
+    await db.execute(
+        insert(UserDailyActivity)
+        .values(user_id=user.id, activity_date=now.date())
+        .on_conflict_do_nothing(index_elements=["user_id", "activity_date"])
+    )
+    await db.commit()
 
 
 async def get_current_db_user(
+    request: Request,
     claims: dict = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> User:
@@ -19,13 +41,18 @@ async def get_current_db_user(
     auth0_sub = claims["sub"]
     result = await db.execute(select(User).where(User.auth0_sub == auth0_sub))
     user = result.scalar_one_or_none()
-    if user is not None:
-        return user
 
-    user = User(auth0_sub=auth0_sub, email=claims.get("email"))
-    db.add(user)
-    await db.commit()
-    await db.refresh(user)
+    if user is None:
+        user = User(auth0_sub=auth0_sub, email=claims.get("email"))
+        db.add(user)
+        await db.commit()
+        await db.refresh(user)
+
+    await _record_activity(user, db)
+    # Read by log_requests (backend/src/core/logging.py) after the route
+    # handler returns, so the access log can attribute a request to a user
+    # without a second JWT decode in the middleware.
+    request.state.user_id = user.id
     return user
 
 

--- a/backend/src/core/logging.py
+++ b/backend/src/core/logging.py
@@ -57,6 +57,13 @@ async def log_requests(
                 "path": request.url.path,
                 "status_code": response.status_code,
                 "duration_ms": duration_ms,
+                # Set by get_current_db_user (backend/src/api/deps.py) once auth
+                # resolves - None for unauthenticated/anonymous requests.
+                "user_id": getattr(request.state, "user_id", None),
+                # CloudFront auto-injects this on every request it forwards to
+                # the origin (infra/modules/cloudfront/main.tf) - absent in
+                # local dev, where requests don't go through CloudFront.
+                "viewer_country": request.headers.get("cloudfront-viewer-country"),
             }
         },
     )

--- a/backend/src/models/__init__.py
+++ b/backend/src/models/__init__.py
@@ -4,6 +4,7 @@ from src.models.bill_event import BillEvent, BillEventType
 from src.models.cycle_override import CycleOverride
 from src.models.transaction import Transaction
 from src.models.user import User
+from src.models.user_daily_activity import UserDailyActivity
 from src.models.windfall import Windfall
 
 __all__ = [
@@ -16,5 +17,6 @@ __all__ = [
     "RecurrenceType",
     "Transaction",
     "User",
+    "UserDailyActivity",
     "Windfall",
 ]

--- a/backend/src/models/user.py
+++ b/backend/src/models/user.py
@@ -26,6 +26,10 @@ class User(Base):
     # there consistently across environments. See docs/ROADMAP.md's
     # consent-tracking note for the full tradeoff.
     terms_accepted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    # Updated at most once/hour by get_current_db_user (backend/src/api/deps.py) - a
+    # cheap write-throttle guard, not a source of historical trends. Durable
+    # per-day history for MAU/DAU/retention queries lives in `user_daily_activity`.
+    last_active_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
 
     bank_accounts: Mapped[list["BankAccount"]] = relationship(
         back_populates="user", cascade="all, delete-orphan"

--- a/backend/src/models/user_daily_activity.py
+++ b/backend/src/models/user_daily_activity.py
@@ -1,0 +1,29 @@
+from datetime import date, datetime
+
+from sqlalchemy import Date, DateTime, ForeignKey, Index, UniqueConstraint, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.core.database import Base
+
+
+class UserDailyActivity(Base):
+    """Append-only record of which calendar days a user was active on.
+
+    One row per (user_id, activity_date), written at most once per user per
+    UTC day by `get_current_db_user`'s activity throttle. Durable history for
+    MAU/DAU/WAU trend and cohort-retention queries, which a single mutable
+    `users.last_active_at` timestamp can't reconstruct after time has passed.
+    """
+
+    __tablename__ = "user_daily_activity"
+    __table_args__ = (
+        UniqueConstraint("user_id", "activity_date", name="uq_user_daily_activity_user_date"),
+        Index("ix_user_daily_activity_activity_date", "activity_date"),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), index=True)
+    activity_date: Mapped[date] = mapped_column(Date)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )

--- a/backend/tests/test_deps.py
+++ b/backend/tests/test_deps.py
@@ -1,0 +1,76 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.core.auth import get_current_user
+from src.main import app
+from src.models import User, UserDailyActivity
+from tests.conftest import auth_as
+
+
+def _login_as(sub: str) -> None:
+    app.dependency_overrides[get_current_user] = auth_as(sub)
+
+
+@pytest.fixture(autouse=True)
+def _default_user():
+    _login_as("auth0|activity_user")
+    yield
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+async def _get_user(db_session: AsyncSession, sub: str) -> User:
+    result = await db_session.execute(select(User).where(User.auth0_sub == sub))
+    return result.scalar_one()
+
+
+async def _daily_activity_rows(db_session: AsyncSession, user_id: int) -> list[UserDailyActivity]:
+    result = await db_session.execute(
+        select(UserDailyActivity).where(UserDailyActivity.user_id == user_id)
+    )
+    return list(result.scalars().all())
+
+
+async def test_first_request_records_activity(client: AsyncClient, db_session: AsyncSession):
+    await client.get("/api/v1/me/consent")
+
+    user = await _get_user(db_session, "auth0|activity_user")
+    assert user.last_active_at is not None
+
+    rows = await _daily_activity_rows(db_session, user.id)
+    assert len(rows) == 1
+    assert rows[0].activity_date == user.last_active_at.date()
+
+
+async def test_repeat_request_within_throttle_does_not_duplicate(
+    client: AsyncClient, db_session: AsyncSession
+):
+    await client.get("/api/v1/me/consent")
+    user = await _get_user(db_session, "auth0|activity_user")
+    first_seen = user.last_active_at
+
+    await client.get("/api/v1/me/consent")
+    db_session.expire_all()
+    user = await _get_user(db_session, "auth0|activity_user")
+    assert user.last_active_at == first_seen
+    assert len(await _daily_activity_rows(db_session, user.id)) == 1
+
+
+async def test_request_after_throttle_window_records_again(
+    client: AsyncClient, db_session: AsyncSession
+):
+    await client.get("/api/v1/me/consent")
+    user = await _get_user(db_session, "auth0|activity_user")
+
+    # Simulate the hourly throttle window having elapsed.
+    user.last_active_at = datetime.now(timezone.utc) - timedelta(hours=2)
+    await db_session.commit()
+
+    await client.get("/api/v1/me/consent")
+    db_session.expire_all()
+    user = await _get_user(db_session, "auth0|activity_user")
+    assert user.last_active_at > datetime.now(timezone.utc) - timedelta(minutes=1)
+    assert len(await _daily_activity_rows(db_session, user.id)) == 1

--- a/docs/ANALYTICS.md
+++ b/docs/ANALYTICS.md
@@ -1,0 +1,120 @@
+# Usage Analytics
+
+How Tally tracks usage and how to look at it. This is the detail behind
+[docs/ROADMAP.md](ROADMAP.md)'s analytics checklist.
+
+## What's tracked and where
+
+Data is split by shape rather than sent to one place:
+
+- **Per-user state (Postgres)** - `users.last_active_at` (a cheap write-throttle guard,
+  updated at most once/hour) and `user_daily_activity` (one row per user per UTC day they
+  were active - the durable history that MAU/DAU/retention queries read from). Both are
+  written by `get_current_db_user` (`backend/src/api/deps.py`) on every authenticated
+  request, so no separate instrumentation is needed per-endpoint.
+- **Per-request detail (CloudWatch Logs)** - the existing JSON access log
+  (`backend/src/core/logging.py`'s `log_requests` middleware) now also includes `user_id`
+  (when authenticated) and `viewer_country` (from the `CloudFront-Viewer-Country` header
+  CloudFront auto-injects on every request it forwards to the origin - absent in local
+  dev, where requests don't go through CloudFront). This is where endpoint popularity,
+  latency, and time-of-day patterns live - deliberately *not* duplicated into Postgres, to
+  avoid a write on every single request.
+
+This split keeps DB writes small (one upsert per user per hour, at most) while still
+answering both "who's active and for how long" (Postgres) and "what are they doing and
+when" (CloudWatch).
+
+## Metrics glossary
+
+Standard SaaS analytics framework (AARRR / "pirate metrics"), with Tally-specific notes:
+
+- **DAU / WAU / MAU** - distinct active users in trailing 1/7/30-day windows. Rolling
+  windows, not calendar day/week/month.
+- **Stickiness (DAU/MAU)** - the standard proxy for "daily habit" vs. "occasional check-in
+  tool". A consumer finance app that's checked a few times a week rather than daily can
+  still be healthy - don't over-index on a low number alone.
+- **Signup trend** - new registrations per week.
+- **Stale accounts** - bucketed by days since last activity: active within 30 days,
+  stale 30-60d, stale 60-90d, stale 90d+, or never active at all. Ken's definition of
+  "stale" is >90 days.
+- **Cohort retention** - of users who signed up in month N, what % were still active in
+  month N+1, N+2, etc. More informative than a single MAU number because it shows whether
+  newer cohorts stick better or worse than older ones.
+- **Feature adoption** (not yet queried, easy to add later) - % of users who've ever used
+  a given feature (windfalls, CSV import, forecast view) - distinguishes "built but
+  ignored" from "core loop". Would need a join against the relevant table's `user_id`
+  (via `bank_accounts`) rather than `user_daily_activity`.
+- **Endpoint popularity / latency / region / time-of-day** - from CloudWatch, not
+  Postgres; see the Logs Insights queries below.
+
+## Running the local report
+
+```bash
+make analytics-report
+```
+
+Equivalent manual form, if you need to run the script outside `make` (e.g. with extra
+args): `set -a` is required since `.secrets` uses plain (non-exported) shell assignments,
+so a plain `source .secrets` won't make the variable visible to the script's subprocess -
+same pattern `infra/Makefile`'s targets use.
+
+```bash
+set -a && source .secrets && set +a
+poetry -C backend run python scripts/analytics/report.py
+```
+
+Prints total users, DAU/WAU/MAU, stickiness, recent signup trend, and the stale-account
+breakdown. Reads `TF_VAR_database_url_readonly` (falling back to `DATABASE_URL_READONLY`,
+the name Terraform maps it to as the Lambda's runtime env var) directly via `asyncpg`
+(no app/ORM dependency) -
+this is the "local process reading from the remote db" approach, reusing the read-only
+Neon credential already provisioned in `.secrets` and `infra/modules/lambda/main.tf` (the
+app itself doesn't consume this var; it's provisioned specifically for external
+read-only reporting like this).
+
+For anything not printed by the script - cohort retention, custom date ranges, ad hoc
+digging - the named queries live in `scripts/analytics/queries.sql`; copy any of them
+into `psql` or a notebook directly.
+
+## CloudWatch Logs Insights companions
+
+Run these in the CloudWatch console against the Lambda's log group
+(`/aws/lambda/tally-backend`) for endpoint/latency/region/time-of-day breakdowns:
+
+```
+# Endpoint popularity
+fields path, method
+| stats count(*) as hits by path, method
+| sort hits desc
+
+# Latency by endpoint (p50/p95)
+fields path, duration_ms
+| stats pct(duration_ms, 50) as p50, pct(duration_ms, 95) as p95, count(*) as hits by path
+| sort hits desc
+
+# Region distribution
+fields viewer_country
+| stats count(*) as hits by viewer_country
+| sort hits desc
+
+# Time-of-day pattern (hour bucket, UTC)
+fields @timestamp
+| stats count(*) as hits by bin(1h)
+```
+
+## Deliberately deferred
+
+- **A local Metabase container** - if the terminal report/raw SQL stops being enough and
+  charts are worth the extra moving part, `docker compose` a `metabase/metabase` container
+  pointed at the same `DATABASE_URL_READONLY`, connected via Metabase's own onboarding UI
+  (no code - it stores its own dashboards/questions in its internal metadata DB). Zero AWS
+  cost since nothing gets deployed; just an extra local container to run when you want to
+  look.
+- **An AWS-hosted, admin-only dashboard** - an IAM-authorizer-gated Lambda + API Gateway
+  route, restricted to admin AWS accounts, so metrics are visible without your laptop.
+  Free-tier cost (no always-on resource), but real setup - treated as a phase 2, not part
+  of the initial build.
+- **Per-request event storage in Postgres** - endpoint/geo/time-of-day intentionally stay
+  in CloudWatch logs rather than a Postgres events table, to avoid a DB write on every
+  request. Revisit only if CloudWatch Logs Insights query costs or retention become a
+  problem at higher traffic than a solo-developer app sees.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -616,6 +616,37 @@ below as items only Ken can close (real money/real lawyer, not something to gues
       cold-start hiccup becomes added latency instead of a broken page. Covered by 4 new
       Vitest cases (`frontend/src/lib/__tests__/api.test.ts`) using fake timers.
 
+## Phase 6 — Usage analytics
+
+**Status**: local-first pass complete - see [docs/ANALYTICS.md](ANALYTICS.md) for the full
+metrics glossary, how to run the report, and the CloudWatch Logs Insights companions. An
+AWS-hosted, admin-only dashboard is an explicit follow-up, not part of this pass.
+
+- [x] Track per-user activity for MAU/DAU/stickiness/stale-account/cohort-retention queries -
+      `users.last_active_at` (throttled to once/hour) + append-only `user_daily_activity`
+      (one row per user per active UTC day), both written by `get_current_db_user`
+      (`backend/src/api/deps.py`) so no per-endpoint instrumentation is needed. A single
+      mutable timestamp can't answer historical trend/cohort questions once time has passed,
+      hence the separate daily-activity table.
+- [x] Attribute the existing per-request access log to a user and a region -
+      `backend/src/core/logging.py`'s `log_requests` now includes `user_id` (set on
+      `request.state` by `get_current_db_user`) and `viewer_country` (CloudFront
+      auto-injects `CloudFront-Viewer-Country` on every request it forwards to the origin -
+      no infra change needed). Endpoint popularity, latency, and time-of-day patterns are
+      queried from CloudWatch Logs Insights, not duplicated into Postgres.
+- [x] Local reporting: `scripts/analytics/queries.sql` (named queries: MAU/DAU/WAU,
+      stickiness, signup trend, stale-account buckets, cohort retention) and
+      `scripts/analytics/report.py` (prints a terminal summary using
+      `DATABASE_URL_READONLY`, already provisioned in `.secrets`/`infra/modules/lambda/main.tf`
+      but previously unused by the app).
+- [ ] AWS-hosted, admin-only dashboard (IAM-authorizer-gated Lambda + API Gateway route) so
+      metrics are visible without a laptop. **Not done this pass** - deferred per Ken's
+      explicit local-first decision; revisit once it's clear which metrics actually get
+      checked regularly.
+- [ ] Feature-adoption metrics (% of users who've ever used windfalls/CSV import/forecast)
+      - not yet queried; would join against each feature's table via `bank_accounts.user_id`
+      rather than `user_daily_activity`.
+
 ## Legacy GitHub Project issue crosswalk
 
 Use this when closing the old project-management issues so their intent stays visible here:

--- a/scripts/analytics/queries.sql
+++ b/scripts/analytics/queries.sql
@@ -1,0 +1,116 @@
+-- Usage-analytics queries for Tally.
+--
+-- Run against DATABASE_URL_READONLY (see .secrets.example) - these are all
+-- read-only. `scripts/analytics/report.py` runs the ones below programmatically
+-- and prints a summary; copy any of these into `psql`, a notebook, or a BI
+-- tool (e.g. a local Metabase pointed at the same read-only URL) directly.
+--
+-- Endpoint popularity / latency / time-of-day / region breakdowns are NOT
+-- here - that data lives in CloudWatch (the JSON access log emitted by
+-- backend/src/core/logging.py), not Postgres. See docs/ANALYTICS.md for the
+-- companion CloudWatch Logs Insights queries.
+
+-- name: total_users
+-- Total registered users.
+SELECT count(*) AS total_users FROM users;
+
+-- name: dau
+-- Distinct users active today (UTC).
+SELECT count(DISTINCT user_id) AS dau
+FROM user_daily_activity
+WHERE activity_date = current_date;
+
+-- name: wau
+-- Distinct users active in the trailing 7 days (rolling window, not calendar week).
+SELECT count(DISTINCT user_id) AS wau
+FROM user_daily_activity
+WHERE activity_date > current_date - interval '7 days';
+
+-- name: mau
+-- Distinct users active in the trailing 30 days (rolling window).
+SELECT count(DISTINCT user_id) AS mau
+FROM user_daily_activity
+WHERE activity_date > current_date - interval '30 days';
+
+-- name: stickiness
+-- DAU/MAU ratio - the standard proxy for "daily habit" vs. "occasional use".
+-- Multiply by 100 for a percentage; industry benchmarks for a healthy
+-- consumer/finance app are often in the 10-25% range.
+SELECT
+    (SELECT count(DISTINCT user_id) FROM user_daily_activity
+     WHERE activity_date = current_date)::numeric
+    / NULLIF((SELECT count(DISTINCT user_id) FROM user_daily_activity
+              WHERE activity_date > current_date - interval '30 days'), 0)
+    AS stickiness_ratio;
+
+-- name: signup_trend
+-- New signups per week, most recent first.
+SELECT date_trunc('week', created_at) AS week, count(*) AS signups
+FROM users
+GROUP BY 1
+ORDER BY 1 DESC;
+
+-- name: stale_accounts
+-- Users bucketed by days since last activity (or never active at all).
+-- "Stale" per Ken's definition = hasn't been used in > 90 days.
+SELECT
+    CASE
+        WHEN last_active IS NULL THEN 'never_active'
+        WHEN last_active > current_date - interval '30 days' THEN 'active_last_30d'
+        WHEN last_active > current_date - interval '60 days' THEN 'stale_30_60d'
+        WHEN last_active > current_date - interval '90 days' THEN 'stale_60_90d'
+        ELSE 'stale_90d_plus'
+    END AS bucket,
+    count(*) AS user_count
+FROM (
+    SELECT u.id, max(a.activity_date) AS last_active
+    FROM users u
+    LEFT JOIN user_daily_activity a ON a.user_id = u.id
+    GROUP BY u.id
+) per_user
+GROUP BY 1
+ORDER BY 1;
+
+-- name: cohort_retention
+-- % of each signup-month cohort still active in each subsequent month.
+-- month_offset 0 = signup month itself, 1 = next month, etc.
+WITH cohorts AS (
+    SELECT id AS user_id, date_trunc('month', created_at) AS cohort_month
+    FROM users
+),
+activity_months AS (
+    SELECT DISTINCT user_id, date_trunc('month', activity_date) AS active_month
+    FROM user_daily_activity
+)
+SELECT
+    c.cohort_month,
+    (extract(year FROM am.active_month) - extract(year FROM c.cohort_month)) * 12
+        + (extract(month FROM am.active_month) - extract(month FROM c.cohort_month))
+        AS month_offset,
+    count(DISTINCT c.user_id) AS active_users
+FROM cohorts c
+JOIN activity_months am ON am.user_id = c.user_id AND am.active_month >= c.cohort_month
+GROUP BY 1, 2
+ORDER BY 1, 2;
+
+-- CloudWatch Logs Insights companions (run in the CloudWatch console against
+-- the Lambda's log group, not here):
+--
+-- Endpoint popularity:
+--   fields path, method
+--   | stats count(*) as hits by path, method
+--   | sort hits desc
+--
+-- Latency by endpoint (p50/p95):
+--   fields path, duration_ms
+--   | stats pct(duration_ms, 50) as p50, pct(duration_ms, 95) as p95, count(*) as hits by path
+--   | sort hits desc
+--
+-- Region distribution:
+--   fields viewer_country
+--   | stats count(*) as hits by viewer_country
+--   | sort hits desc
+--
+-- Time-of-day pattern (hour bucket, UTC):
+--   fields @timestamp
+--   | stats count(*) as hits by bin(1h)

--- a/scripts/analytics/report.py
+++ b/scripts/analytics/report.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Prints a terminal summary of Tally usage metrics.
+
+The "local process reading from the remote db" option: reads
+TF_VAR_database_url_readonly (or DATABASE_URL_READONLY) from the environment
+and runs the named queries in queries.sql against it directly (no app/ORM
+dependency).
+
+Usage:
+    make analytics-report
+
+    # Equivalent manual form (set -a is required: .secrets uses plain,
+    # non-exported shell assignments, so a plain `source .secrets` never
+    # makes the variable visible to this script's subprocess - see
+    # infra/Makefile's targets for the same pattern):
+    set -a && source .secrets && set +a
+    poetry -C backend run python scripts/analytics/report.py
+"""
+import asyncio
+import os
+import re
+import sys
+from pathlib import Path
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+import asyncpg
+
+QUERIES_PATH = Path(__file__).parent / "queries.sql"
+
+
+def _load_named_queries() -> dict[str, str]:
+    text = QUERIES_PATH.read_text()
+    blocks = re.split(r"^-- name: (\S+)\n", text, flags=re.MULTILINE)[1:]
+    queries = {}
+    for name, body in zip(blocks[0::2], blocks[1::2]):
+        sql = "\n".join(
+            line for line in body.splitlines() if not line.strip().startswith("--")
+        ).strip()
+        if sql:
+            queries[name] = sql.rstrip(";")
+    return queries
+
+
+def _normalize_dsn(dsn: str) -> str:
+    # asyncpg's DSN parser doesn't recognize libpq-only params - Neon's
+    # connection strings include channel_binding for psycopg clients, and
+    # passing it through makes Postgres reject the connection with
+    # "unrecognized configuration parameter". Safe to drop: TLS already
+    # covers the transport; channel binding is an additional SCRAM
+    # enhancement asyncpg doesn't implement.
+    parts = urlsplit(dsn)
+    params = [(k, v) for k, v in parse_qsl(parts.query) if k != "channel_binding"]
+    return urlunsplit(parts._replace(query=urlencode(params)))
+
+
+async def _run(dsn: str) -> None:
+    queries = _load_named_queries()
+    conn = await asyncpg.connect(_normalize_dsn(dsn))
+    try:
+        total_users = await conn.fetchval(queries["total_users"])
+        dau = await conn.fetchval(queries["dau"])
+        wau = await conn.fetchval(queries["wau"])
+        mau = await conn.fetchval(queries["mau"])
+        stickiness = await conn.fetchval(queries["stickiness"])
+
+        print("Tally usage summary")
+        print("====================")
+        print(f"Total registered users : {total_users}")
+        print(f"DAU                    : {dau}")
+        print(f"WAU                    : {wau}")
+        print(f"MAU                    : {mau}")
+        stickiness_str = f"{stickiness:.1%}" if stickiness is not None else "n/a"
+        print(f"Stickiness (DAU/MAU)   : {stickiness_str}")
+
+        print("\nSignups per week (last 8)")
+        print("-------------------------")
+        for row in (await conn.fetch(queries["signup_trend"]))[:8]:
+            print(f"  {row['week'].date()}  {row['signups']:>4}")
+
+        print("\nStale accounts")
+        print("--------------")
+        for row in await conn.fetch(queries["stale_accounts"]):
+            print(f"  {row['bucket']:<18} {row['user_count']:>4}")
+    finally:
+        await conn.close()
+
+
+def main() -> None:
+    # .secrets sets TF_VAR_database_url_readonly (Terraform's env-var naming
+    # convention for auto-loading tfvars) - DATABASE_URL_READONLY is only the
+    # name Terraform maps it to as the Lambda's runtime env var, so it's
+    # never actually set by `source .secrets`. Check both so this also works
+    # if someone exports DATABASE_URL_READONLY directly.
+    dsn = os.environ.get("TF_VAR_database_url_readonly") or os.environ.get(
+        "DATABASE_URL_READONLY"
+    )
+    if not dsn:
+        print(
+            "Neither TF_VAR_database_url_readonly nor DATABASE_URL_READONLY is set - "
+            "run `set -a && source .secrets && set +a` first (a plain `source .secrets` "
+            "doesn't export it - see .secrets.example).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    asyncio.run(_run(dsn))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds per-user activity tracking: `users.last_active_at` (throttled to once/hour, write-throttle guard) + append-only `user_daily_activity` (one row per user per active UTC day), recorded by the existing `get_current_db_user` dependency (`backend/src/api/deps.py`) - no new per-endpoint instrumentation needed.
- Attributes the existing per-request JSON access log (`backend/src/core/logging.py`) to a `user_id` and a `viewer_country` (from CloudFront's auto-injected `CloudFront-Viewer-Country` header), so endpoint popularity/latency/region/time-of-day are queryable from CloudWatch Logs Insights without duplicating event data into Postgres.
- Ships the local-first reporting path (per explicit decision, AWS-hosted admin dashboard deferred as a follow-up): `scripts/analytics/queries.sql` (MAU/DAU/WAU, stickiness, signup trend, stale-account buckets, cohort retention) + `scripts/analytics/report.py` (prints a terminal summary via the already-provisioned `DATABASE_URL_READONLY`/`TF_VAR_database_url_readonly`), wired up as `make analytics-report`.
- `docs/ANALYTICS.md` documents the metrics glossary, how to run the report, and the CloudWatch Logs Insights companion queries. `docs/ROADMAP.md` gets a new Phase 6 tracking this + the two deferred follow-ups (AWS admin dashboard, feature-adoption metrics).

## Test plan

- [x] `cd backend && poetry run pytest tests/ -q` - all 154 tests pass, including new `tests/test_deps.py` covering the throttled activity-recording behavior
- [x] `alembic stamp base && alembic upgrade head` applies cleanly against local dev Postgres
- [x] `make analytics-report` verified against the real Neon database (read-only) - connects and queries `users` successfully; correctly errors on `user_daily_activity` until this PR's migration deploys via `terraform-apply.yml`
- [ ] Once merged, confirm `terraform-apply.yml` applies the new migration to prod and `make analytics-report` runs end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)