### PR TITLE
Bump GitHub Actions off deprecated node20 runtime

### DIFF
--- a/.github/action-versions.conf
+++ b/.github/action-versions.conf
@@ -3,9 +3,9 @@
 # The pre-commit hook will validate that all workflow files use these exact versions.
 
 actions/checkout: v5
-aws-actions/configure-aws-credentials: v4
-hashicorp/setup-terraform: v3
-actions/cache: v4
-actions/github-script: v7
-actions/setup-node: v4
-actions/setup-python: v5
+aws-actions/configure-aws-credentials: v6
+hashicorp/setup-terraform: v4
+actions/cache: v5
+actions/github-script: v8
+actions/setup-node: v5
+actions/setup-python: v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
       - name: Test
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version-file: ./frontend/.nvmrc
       - name: Test

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Cache Yarn Dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/yarn
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
@@ -75,7 +75,7 @@ jobs:
           fi
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           role-session-name: deploy-frontend-${{ github.run_id }}

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -36,18 +36,18 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           role-session-name: terraform-apply-${{ github.run_id }}
           aws-region: us-west-2
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@v4
         with:
           terraform_wrapper: false
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ./infra/.terraform
           key: terraform-${{ hashFiles('./infra/.terraform.lock.hcl') }}

--- a/.github/workflows/terraform-pr.yml
+++ b/.github/workflows/terraform-pr.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Check for infra changes
         id: infra_changes
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const files = await github.paginate(
@@ -37,18 +37,18 @@ jobs:
         if: steps.infra_changes.outputs.noop == 'true'
         run: echo "No infra changes detected. Skipping Terraform steps."
 
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         if: steps.infra_changes.outputs.noop != 'true'
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-west-2
 
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@v4
         if: steps.infra_changes.outputs.noop != 'true'
         with:
           terraform_wrapper: false
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         if: steps.infra_changes.outputs.noop != 'true'
         with:
           path: .terraform
@@ -89,7 +89,7 @@ jobs:
 
       - name: Comment
         if: github.event_name == 'pull_request' && steps.plan.outputs.exit_code != '0'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
## Summary

- No app/test code change needed: the previously-reported "frontend vitest is broken" was a local-machine issue only. It was `jsdom`'s current dependency chain (`html-encoding-sniffer@6.0.0` → `@exodus/bytes`, ESM-only) requiring Node's native `require(esm)` interop, which needs Node `^20.19.0 || ^22.12.0 || >=24.0.0`. This session had manually forced Node `22.9.0` (just under the `22.12.0` cutoff) instead of respecting `frontend/.nvmrc`. Confirmed clean with `nvm use` (reads `.nvmrc` → resolves 24.11.0): `svelte-check` 0 errors, `vitest` 7/7 files, 23/23 tests passing.
- Confirmed CI's `frontend-test` job (in `ci.yml`) already exists, already mirrors `backend-test`'s structure (checkout → language setup from a version file → install → test), and already passed on the last merged PR (#102) — so frontend tests are already executed the same way as backend tests in CI. Nothing to add there.
- Bumped 6 pinned GitHub Actions off the deprecated `node20` Actions runtime to the earliest major each publishes with `node24`, since every job was emitting `Node.js 20 is deprecated ... forced to run on Node.js 24` warnings:
  - `actions/setup-node` v4 → v5
  - `actions/setup-python` v5 → v6
  - `aws-actions/configure-aws-credentials` v4 → v6 (v5 is still node20)
  - `hashicorp/setup-terraform` v3 → v4
  - `actions/cache` v4 → v5
  - `actions/github-script` v7 → v8
  - (`actions/checkout@v5` was already node24 — untouched)
  - Updated `.github/action-versions.conf` to match, keeping the existing major-version-pin convention.

## Test plan

- [x] `make validate-actions` — all 5 workflow files pass
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on each edited workflow file — valid YAML
- [x] `nvm use && npx svelte-check` — 0 errors, 0 warnings
- [x] `nvm use && npx vitest run` — 7 files / 23 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
