### PR TITLE
feat: flag one-time/ended bills, unify row actions into a kebab menu

### DIFF
--- a/backend/src/api/bills.py
+++ b/backend/src/api/bills.py
@@ -6,7 +6,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.api.deps import get_bank_account_or_404, get_current_db_user, get_owned_bank_account
-from src.bill_events import TRACKED_BILL_FIELDS, created_event, update_events
+from src.bill_events import TRACKED_BILL_FIELDS, created_event, expired_event, update_events
 from src.bills_csv import bills_to_csv, parse_csv_rows
 from src.core.database import get_db
 from src.forecast import ForecastBill, ForecastCycleOverride, build_bill_history, last_cycle_end
@@ -39,13 +39,40 @@ async def _get_owned_bill(
     return bill
 
 
+async def _auto_disable_expired(db: AsyncSession, bills: list[Bill]) -> None:
+    """A bill whose end_date has passed is functionally dead - no forecast
+    cycle will ever include it again - but was otherwise left enabled
+    indefinitely with no cron/scheduler to catch it (this app has none, by
+    design - see CLAUDE.md's cost-first philosophy). Disabling it lazily,
+    the next time bills are listed, flags it via the existing Enabled/
+    Disabled badge without needing a background job.
+    """
+    today = date.today()
+    expired = [
+        bill for bill in bills if bill.enabled and bill.end_date is not None and bill.end_date < today
+    ]
+    if not expired:
+        return
+    for bill in expired:
+        bill.enabled = False
+    db.add_all(expired_event(bill) for bill in expired)
+    await db.commit()
+    # updated_at's onupdate=func.now() is server-computed - without a
+    # refresh, the response would try to lazy-load it outside any awaited
+    # context (Pydantic serialization happens after the endpoint returns).
+    for bill in expired:
+        await db.refresh(bill)
+
+
 @router.get("", response_model=list[BillRead])
 async def list_bills(
     db: AsyncSession = Depends(get_db),
     account: BankAccount = Depends(get_owned_bank_account),
 ) -> list[Bill]:
     result = await db.execute(select(Bill).where(Bill.account_id == account.id))
-    return list(result.scalars().all())
+    bills = list(result.scalars().all())
+    await _auto_disable_expired(db, bills)
+    return bills
 
 
 @router.post("", response_model=BillRead, status_code=status.HTTP_201_CREATED)

--- a/backend/src/api/transactions.py
+++ b/backend/src/api/transactions.py
@@ -2,9 +2,9 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.api.deps import get_owned_bank_account
+from src.api.deps import get_bank_account_or_404, get_current_db_user, get_owned_bank_account
 from src.core.database import get_db
-from src.models import BankAccount, Bill, Transaction
+from src.models import BankAccount, Bill, Transaction, User
 from src.schemas.transaction import TransactionCreate, TransactionRead, TransactionUpdate
 
 router = APIRouter(prefix="/api/v1/accounts/{account_id}/transactions", tags=["transactions"])
@@ -83,9 +83,15 @@ async def update_transaction(
     db: AsyncSession = Depends(get_db),
     account: BankAccount = Depends(get_owned_bank_account),
     transaction: Transaction = Depends(_get_owned_transaction),
+    current_user: User = Depends(get_current_db_user),
 ) -> Transaction:
     update_data = payload.model_dump(exclude_unset=True)
     _reject_explicit_nulls(update_data)
+    if "account_id" in update_data:
+        # Moving to another account - the target must also belong to the
+        # current user, same as get_owned_bank_account already validated for
+        # the *current* account_id from the URL (mirrors Bill's move).
+        await get_bank_account_or_404(update_data["account_id"], db, current_user)
     if "bill_id" in update_data:
         await _validate_bill_id(update_data["bill_id"], account.id, db)
     for field, value in update_data.items():

--- a/backend/src/api/windfalls.py
+++ b/backend/src/api/windfalls.py
@@ -2,9 +2,9 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.api.deps import get_owned_bank_account
+from src.api.deps import get_bank_account_or_404, get_current_db_user, get_owned_bank_account
 from src.core.database import get_db
-from src.models import BankAccount, Windfall
+from src.models import BankAccount, User, Windfall
 from src.schemas.windfall import WindfallCreate, WindfallRead, WindfallUpdate
 
 router = APIRouter(prefix="/api/v1/accounts/{account_id}/windfalls", tags=["windfalls"])
@@ -70,9 +70,15 @@ async def update_windfall(
     payload: WindfallUpdate,
     db: AsyncSession = Depends(get_db),
     windfall: Windfall = Depends(_get_owned_windfall),
+    current_user: User = Depends(get_current_db_user),
 ) -> Windfall:
     update_data = payload.model_dump(exclude_unset=True)
     _reject_explicit_nulls(update_data)
+    if "account_id" in update_data:
+        # Moving to another account - the target must also belong to the
+        # current user, same as get_owned_bank_account already validated for
+        # the *current* account_id from the URL (mirrors Bill's move).
+        await get_bank_account_or_404(update_data["account_id"], db, current_user)
     for field, value in update_data.items():
         setattr(windfall, field, value)
     await db.commit()

--- a/backend/src/bill_events.py
+++ b/backend/src/bill_events.py
@@ -40,6 +40,16 @@ def created_event(bill: Bill) -> BillEvent:
     )
 
 
+def expired_event(bill: Bill) -> BillEvent:
+    """Bill auto-disabled because its end_date has passed (see
+    _auto_disable_expired in src/api/bills.py) - a plain DISABLED event, same
+    as a manual toggle, since there's no per-field diff to show and the
+    timeline already labels every DISABLED event the same way regardless of
+    cause.
+    """
+    return BillEvent(account_id=bill.account_id, bill_id=bill.id, event_type=BillEventType.DISABLED)
+
+
 def update_events(
     bill: Bill, update_data: dict[str, Any], before: dict[str, Any]
 ) -> list[BillEvent]:

--- a/backend/src/schemas/transaction.py
+++ b/backend/src/schemas/transaction.py
@@ -26,6 +26,7 @@ class TransactionUpdate(BaseModel):
     date: date_ | None = None
     description: str | None = None
     bill_id: int | None = None
+    account_id: int | None = None
 
 
 class TransactionRead(BaseModel):

--- a/backend/src/schemas/windfall.py
+++ b/backend/src/schemas/windfall.py
@@ -14,6 +14,7 @@ class WindfallUpdate(BaseModel):
     name: str | None = None
     amount_cents: int | None = Field(default=None, gt=0)
     expected_date: date | None = None
+    account_id: int | None = None
 
 
 class WindfallRead(BaseModel):

--- a/backend/tests/test_bills_api.py
+++ b/backend/tests/test_bills_api.py
@@ -1,3 +1,5 @@
+from datetime import date, timedelta
+
 import pytest
 from httpx import AsyncClient
 
@@ -117,6 +119,59 @@ async def test_toggle_bill_enabled(client: AsyncClient):
     )
     assert res.status_code == 200
     assert res.json()["enabled"] is False
+
+
+async def test_bill_past_end_date_auto_disabled_on_list(client: AsyncClient):
+    account = await _create_account(client)
+    past_end_date = date.today() - timedelta(days=1)
+    bill = (
+        await client.post(
+            f"/api/v1/accounts/{account['id']}/bills",
+            json=_bill_payload(end_date=past_end_date.isoformat()),
+        )
+    ).json()
+    assert bill["enabled"] is True
+
+    res = await client.get(f"/api/v1/accounts/{account['id']}/bills")
+    assert res.status_code == 200
+    assert res.json()[0]["enabled"] is False
+
+    events_res = await client.get(f"/api/v1/accounts/{account['id']}/bills/{bill['id']}/events")
+    event_types = [e["event_type"] for e in events_res.json()["events"]]
+    assert event_types == ["disabled", "created"]
+
+
+async def test_bill_future_end_date_stays_enabled_on_list(client: AsyncClient):
+    account = await _create_account(client)
+    future_end_date = date.today() + timedelta(days=1)
+    bill = (
+        await client.post(
+            f"/api/v1/accounts/{account['id']}/bills",
+            json=_bill_payload(end_date=future_end_date.isoformat()),
+        )
+    ).json()
+
+    res = await client.get(f"/api/v1/accounts/{account['id']}/bills")
+    assert res.json()[0]["enabled"] is True
+    assert bill["enabled"] is True
+
+
+async def test_manually_disabled_bill_past_end_date_not_double_flagged(client: AsyncClient):
+    account = await _create_account(client)
+    past_end_date = date.today() - timedelta(days=1)
+    bill = (
+        await client.post(
+            f"/api/v1/accounts/{account['id']}/bills",
+            json=_bill_payload(end_date=past_end_date.isoformat(), enabled=False),
+        )
+    ).json()
+
+    res = await client.get(f"/api/v1/accounts/{account['id']}/bills")
+    assert res.json()[0]["enabled"] is False
+
+    events_res = await client.get(f"/api/v1/accounts/{account['id']}/bills/{bill['id']}/events")
+    event_types = [e["event_type"] for e in events_res.json()["events"]]
+    assert event_types == ["created"]
 
 
 async def test_delete_bill(client: AsyncClient):

--- a/backend/tests/test_transactions_api.py
+++ b/backend/tests/test_transactions_api.py
@@ -78,6 +78,47 @@ async def test_update_transaction(client: AsyncClient):
     assert res.json()["amount_cents"] == 500
 
 
+async def test_move_transaction_to_another_owned_account(client: AsyncClient):
+    account_a = await _create_account(client)
+    account_b = (await client.post("/api/v1/accounts", json={"name": "Savings"})).json()
+    transaction = (
+        await client.post(
+            f"/api/v1/accounts/{account_a['id']}/transactions", json=_transaction_payload()
+        )
+    ).json()
+
+    res = await client.patch(
+        f"/api/v1/accounts/{account_a['id']}/transactions/{transaction['id']}",
+        json={"account_id": account_b["id"]},
+    )
+    assert res.status_code == 200
+    assert res.json()["account_id"] == account_b["id"]
+
+    res = await client.get(f"/api/v1/accounts/{account_a['id']}/transactions")
+    assert res.json() == []
+    res = await client.get(f"/api/v1/accounts/{account_b['id']}/transactions")
+    assert len(res.json()) == 1
+
+
+async def test_cannot_move_transaction_to_another_users_account(client: AsyncClient):
+    account = await _create_account(client)
+    transaction = (
+        await client.post(
+            f"/api/v1/accounts/{account['id']}/transactions", json=_transaction_payload()
+        )
+    ).json()
+
+    _login_as("auth0|someone-else")
+    other_account = (await client.post("/api/v1/accounts", json={"name": "Their account"})).json()
+    _login_as("auth0|owner")
+
+    res = await client.patch(
+        f"/api/v1/accounts/{account['id']}/transactions/{transaction['id']}",
+        json={"account_id": other_account["id"]},
+    )
+    assert res.status_code == 404
+
+
 async def test_update_transaction_rejects_explicit_null_on_required_field(client: AsyncClient):
     account = await _create_account(client)
     transaction = (

--- a/backend/tests/test_windfalls_api.py
+++ b/backend/tests/test_windfalls_api.py
@@ -77,6 +77,47 @@ async def test_update_windfall(client: AsyncClient):
     assert res.json()["amount_cents"] == 75000
 
 
+async def test_move_windfall_to_another_owned_account(client: AsyncClient):
+    account_a = await _create_account(client)
+    account_b = (await client.post("/api/v1/accounts", json={"name": "Savings"})).json()
+    windfall = (
+        await client.post(
+            f"/api/v1/accounts/{account_a['id']}/windfalls", json=_windfall_payload()
+        )
+    ).json()
+
+    res = await client.patch(
+        f"/api/v1/accounts/{account_a['id']}/windfalls/{windfall['id']}",
+        json={"account_id": account_b["id"]},
+    )
+    assert res.status_code == 200
+    assert res.json()["account_id"] == account_b["id"]
+
+    res = await client.get(f"/api/v1/accounts/{account_a['id']}/windfalls")
+    assert res.json() == []
+    res = await client.get(f"/api/v1/accounts/{account_b['id']}/windfalls")
+    assert len(res.json()) == 1
+
+
+async def test_cannot_move_windfall_to_another_users_account(client: AsyncClient):
+    account = await _create_account(client)
+    windfall = (
+        await client.post(
+            f"/api/v1/accounts/{account['id']}/windfalls", json=_windfall_payload()
+        )
+    ).json()
+
+    _login_as("auth0|someone-else")
+    other_account = (await client.post("/api/v1/accounts", json={"name": "Their account"})).json()
+    _login_as("auth0|owner")
+
+    res = await client.patch(
+        f"/api/v1/accounts/{account['id']}/windfalls/{windfall['id']}",
+        json={"account_id": other_account["id"]},
+    )
+    assert res.status_code == 404
+
+
 async def test_update_windfall_rejects_explicit_null_on_required_field(client: AsyncClient):
     account = await _create_account(client)
     windfall = (

--- a/frontend/src/lib/api/transactions.ts
+++ b/frontend/src/lib/api/transactions.ts
@@ -15,6 +15,17 @@ export function createTransaction(
 	});
 }
 
+export function updateTransaction(
+	accountId: number,
+	transactionId: number,
+	input: Partial<TransactionInput> & { account_id?: number }
+): Promise<Transaction> {
+	return apiJson(`/api/v1/accounts/${accountId}/transactions/${transactionId}`, {
+		method: 'PATCH',
+		body: JSON.stringify(input)
+	});
+}
+
 export function deleteTransaction(accountId: number, transactionId: number): Promise<void> {
 	return apiJson(`/api/v1/accounts/${accountId}/transactions/${transactionId}`, {
 		method: 'DELETE'

--- a/frontend/src/lib/api/windfalls.ts
+++ b/frontend/src/lib/api/windfalls.ts
@@ -12,6 +12,17 @@ export function createWindfall(accountId: number, input: WindfallInput): Promise
 	});
 }
 
+export function updateWindfall(
+	accountId: number,
+	windfallId: number,
+	input: Partial<WindfallInput> & { account_id?: number }
+): Promise<Windfall> {
+	return apiJson(`/api/v1/accounts/${accountId}/windfalls/${windfallId}`, {
+		method: 'PATCH',
+		body: JSON.stringify(input)
+	});
+}
+
 export function deleteWindfall(accountId: number, windfallId: number): Promise<void> {
 	return apiJson(`/api/v1/accounts/${accountId}/windfalls/${windfallId}`, {
 		method: 'DELETE'

--- a/frontend/src/lib/components/RowActionsMenu.svelte
+++ b/frontend/src/lib/components/RowActionsMenu.svelte
@@ -1,0 +1,102 @@
+<script lang="ts">
+	let {
+		label = 'Actions',
+		actions
+	}: {
+		label?: string;
+		actions: { label: string; onclick: () => void; variant?: 'default' | 'danger' }[];
+	} = $props();
+
+	let open = $state(false);
+	let triggerEl = $state<HTMLButtonElement | undefined>();
+	let menuEl = $state<HTMLDivElement | undefined>();
+	let menuStyle = $state('');
+
+	// Rows live inside Table's overflow-x-auto wrapper - per the CSS overflow
+	// spec, setting overflow-x alone still computes overflow-y to auto too,
+	// so a menu positioned relative to its row (the natural approach) gets
+	// silently clipped by the table's own bottom edge for any row near the
+	// end of the list. Positioning it via `fixed` + a portal to <body>
+	// escapes that clipping ancestor entirely.
+	function positionMenu() {
+		if (!triggerEl) return;
+		const rect = triggerEl.getBoundingClientRect();
+		menuStyle = `position: fixed; top: ${rect.bottom + 4}px; right: ${window.innerWidth - rect.right}px;`;
+	}
+
+	function toggle() {
+		if (open) {
+			open = false;
+			return;
+		}
+		positionMenu();
+		open = true;
+	}
+
+	function handleWindowClick(event: MouseEvent) {
+		if (!open) return;
+		const target = event.target as Node;
+		if (triggerEl?.contains(target) || menuEl?.contains(target)) return;
+		open = false;
+	}
+
+	function handleKeydown(event: KeyboardEvent) {
+		if (event.key === 'Escape') open = false;
+	}
+
+	function trigger(action: { onclick: () => void }) {
+		open = false;
+		action.onclick();
+	}
+
+	// Moves the menu's DOM node to <body> on mount so `position: fixed`
+	// above is relative to the viewport, not the (clipped) Table ancestor.
+	function portal(node: HTMLElement) {
+		document.body.appendChild(node);
+		return {
+			destroy() {
+				node.remove();
+			}
+		};
+	}
+</script>
+
+<svelte:window
+	onclick={handleWindowClick}
+	onkeydown={open ? handleKeydown : undefined}
+	onscroll={open ? () => (open = false) : undefined}
+/>
+
+<button
+	bind:this={triggerEl}
+	type="button"
+	onclick={toggle}
+	aria-haspopup="menu"
+	aria-expanded={open}
+	aria-label={label}
+	class="rounded-card px-2 py-1 text-lg leading-none text-slate-500 hover:bg-slate-100 hover:text-text focus:outline-none focus:ring-1 focus:ring-primary"
+>
+	&#8942;
+</button>
+
+{#if open}
+	<div use:portal bind:this={menuEl} role="menu" style={menuStyle} class="z-50">
+		<div
+			class="min-w-[8rem] rounded-card border border-slate-200 bg-surface py-1 shadow-card"
+		>
+			{#each actions as action (action.label)}
+				<button
+					type="button"
+					role="menuitem"
+					onclick={() => trigger(action)}
+					class="block w-full px-3 py-1.5 text-left text-sm hover:bg-slate-100 {action.variant ===
+					'danger'
+						? 'text-red-700'
+						: 'text-text'}"
+				>
+					{action.label}
+				</button>
+			{/each}
+		</div>
+	</div>
+{/if}

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -7,3 +7,13 @@ export function accountSuffix(account: BankAccount | null): string {
 	if (!account) return '';
 	return ` (${account.name}${account.institution ? ` - ${account.institution}` : ''})`;
 }
+
+// Local date components, not toISOString() (which formats in UTC and can
+// shift the day relative to the user's local time).
+export function todayIso(): string {
+	const now = new Date();
+	const year = now.getFullYear();
+	const month = String(now.getMonth() + 1).padStart(2, '0');
+	const day = String(now.getDate()).padStart(2, '0');
+	return `${year}-${month}-${day}`;
+}

--- a/frontend/src/lib/glossary.ts
+++ b/frontend/src/lib/glossary.ts
@@ -51,5 +51,15 @@ export const glossaryTerms: GlossaryTerm[] = [
 		term: 'Bill history',
 		definition:
 			"A cycle-by-cycle log of a single bill's expected vs. actual amounts, completion, and notes over time - useful for spotting bills that consistently run over their usual amount."
+	},
+	{
+		term: 'One-time bill',
+		definition:
+			'A bill whose start date and end date are the same day only ever occurs once - functionally identical to a one-off Transaction, but modeled as a recurring Bill. Consider deleting it and recording the expense as a Transaction instead, since Bills are meant for things that repeat.'
+	},
+	{
+		term: 'Ended bill',
+		definition:
+			"A bill whose end date has passed - it no longer applies to any forecast cycle. Tally automatically disables it so it's easy to review and delete during cleanup, rather than leaving it enabled but functionally dead."
 	}
 ];

--- a/frontend/src/routes/(app)/accounts/[id]/+page.svelte
+++ b/frontend/src/routes/(app)/accounts/[id]/+page.svelte
@@ -12,7 +12,7 @@
 	} from '$lib/api/bills';
 	import { ApiError } from '$lib/api';
 	import type { BankAccount, Bill, RecurrenceType } from '$lib/api/types';
-	import { accountSuffix } from '$lib/format';
+	import { accountSuffix, todayIso } from '$lib/format';
 	import AccountNav from '$lib/components/AccountNav.svelte';
 	import Badge from '$lib/components/Badge.svelte';
 	import Button from '$lib/components/Button.svelte';
@@ -21,13 +21,26 @@
 	import Input from '$lib/components/Input.svelte';
 	import Modal from '$lib/components/Modal.svelte';
 	import RecurrenceConfigFields from '$lib/components/RecurrenceConfigFields.svelte';
+	import RowActionsMenu from '$lib/components/RowActionsMenu.svelte';
 	import Select from '$lib/components/Select.svelte';
 	import Table from '$lib/components/Table.svelte';
+	import Tooltip from '$lib/components/Tooltip.svelte';
 	import { glossaryTerms } from '$lib/glossary';
 	import { recurrenceLabels } from '$lib/recurrence';
 	import { onMount } from 'svelte';
 
 	const frequencyTooltip = glossaryTerms.find((t) => t.term === 'Frequency')!.definition;
+	const oneTimeTooltip = glossaryTerms.find((t) => t.term === 'One-time bill')!.definition;
+	const endedTooltip = glossaryTerms.find((t) => t.term === 'Ended bill')!.definition;
+	const today = todayIso();
+
+	function isOneTimeBill(bill: Bill): boolean {
+		return bill.end_date !== null && bill.start_date === bill.end_date;
+	}
+
+	function isEndedBill(bill: Bill): boolean {
+		return bill.end_date !== null && bill.end_date < today;
+	}
 
 	const accountId = $derived(Number($page.params.id));
 
@@ -350,7 +363,27 @@
 			<tbody>
 				{#each bills as bill (bill.id)}
 					<tr class="border-b border-slate-100 last:border-0">
-						<td class="px-4 py-2">{bill.name}</td>
+						<td class="px-4 py-2">
+							<div class="flex flex-wrap items-center gap-1.5">
+								<span>{bill.name}</span>
+								{#if isOneTimeBill(bill)}
+									<span
+										class="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800"
+									>
+										One-time
+										<Tooltip text={oneTimeTooltip} />
+									</span>
+								{/if}
+								{#if isEndedBill(bill)}
+									<span
+										class="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800"
+									>
+										Ended
+										<Tooltip text={endedTooltip} />
+									</span>
+								{/if}
+							</div>
+						</td>
 						<td class="px-4 py-2">{formatAmount(bill.amount_cents)}</td>
 						<td class="px-4 py-2 text-slate-600">{recurrenceLabels[bill.recurrence_type]}</td>
 						<td class="px-4 py-2">
@@ -366,9 +399,14 @@
 								>
 									History
 								</a>
-								<Button variant="secondary" onclick={() => openEditModal(bill)}>Edit</Button>
-								<Button variant="secondary" onclick={() => openMoveModal(bill)}>Move</Button>
-								<Button variant="danger" onclick={() => handleDelete(bill.id)}>Delete</Button>
+								<RowActionsMenu
+									label="Bill actions"
+									actions={[
+										{ label: 'Edit', onclick: () => openEditModal(bill) },
+										{ label: 'Move', onclick: () => openMoveModal(bill) },
+										{ label: 'Delete', onclick: () => handleDelete(bill.id), variant: 'danger' }
+									]}
+								/>
 							</div>
 						</td>
 					</tr>

--- a/frontend/src/routes/(app)/accounts/[id]/transactions/+page.svelte
+++ b/frontend/src/routes/(app)/accounts/[id]/transactions/+page.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
 	import { page } from '$app/stores';
-	import { getAccount } from '$lib/api/accounts';
-	import { createTransaction, deleteTransaction, listTransactions } from '$lib/api/transactions';
+	import { getAccount, listAccounts } from '$lib/api/accounts';
+	import {
+		createTransaction,
+		deleteTransaction,
+		listTransactions,
+		updateTransaction
+	} from '$lib/api/transactions';
 	import type { BankAccount, Transaction } from '$lib/api/types';
 	import { accountSuffix } from '$lib/format';
 	import AccountNav from '$lib/components/AccountNav.svelte';
@@ -9,12 +14,16 @@
 	import Card from '$lib/components/Card.svelte';
 	import DatePicker from '$lib/components/DatePicker.svelte';
 	import Input from '$lib/components/Input.svelte';
+	import Modal from '$lib/components/Modal.svelte';
+	import RowActionsMenu from '$lib/components/RowActionsMenu.svelte';
+	import Select from '$lib/components/Select.svelte';
 	import Table from '$lib/components/Table.svelte';
 	import { onMount } from 'svelte';
 
 	const accountId = $derived(Number($page.params.id));
 
 	let account = $state<BankAccount | null>(null);
+	let accounts = $state<BankAccount[]>([]);
 	let transactions = $state<Transaction[]>([]);
 	let loading = $state(true);
 	let error = $state<string | null>(null);
@@ -24,14 +33,35 @@
 	let description = $state('');
 	let creating = $state(false);
 
-	async function load() {
+	let editingTransaction = $state<Transaction | null>(null);
+	let editAmount = $state('');
+	let editDate = $state('');
+	let editDescription = $state('');
+	let saving = $state(false);
+	let showEditModal = $state(false);
+
+	let movingTransaction = $state<Transaction | null>(null);
+	let moveTargetAccountId = $state('');
+	let moving = $state(false);
+	let showMoveModal = $state(false);
+
+	// Account details and the accounts list (for the move-transaction picker)
+	// only change when navigating here or moving a transaction elsewhere
+	// entirely - they don't need refetching after every create/delete,
+	// unlike transactions itself.
+	async function loadContext() {
+		try {
+			[account, accounts] = await Promise.all([getAccount(accountId), listAccounts()]);
+		} catch (err) {
+			error = err instanceof Error ? err.message : String(err);
+		}
+	}
+
+	async function loadTransactions() {
 		loading = true;
 		error = null;
 		try {
-			[account, transactions] = await Promise.all([
-				getAccount(accountId),
-				listTransactions(accountId)
-			]);
+			transactions = await listTransactions(accountId);
 		} catch (err) {
 			error = err instanceof Error ? err.message : String(err);
 		} finally {
@@ -39,7 +69,10 @@
 		}
 	}
 
-	onMount(load);
+	onMount(() => {
+		loadContext();
+		loadTransactions();
+	});
 
 	async function handleCreate(event: SubmitEvent) {
 		event.preventDefault();
@@ -58,7 +91,7 @@
 			amount = '';
 			date = '';
 			description = '';
-			await load();
+			await loadTransactions();
 		} catch (err) {
 			error = err instanceof Error ? err.message : String(err);
 		} finally {
@@ -69,9 +102,64 @@
 	async function handleDelete(transactionId: number) {
 		try {
 			await deleteTransaction(accountId, transactionId);
-			await load();
+			await loadTransactions();
 		} catch (err) {
 			error = err instanceof Error ? err.message : String(err);
+		}
+	}
+
+	function openEditModal(transaction: Transaction) {
+		editingTransaction = transaction;
+		editAmount = (transaction.amount_cents / 100).toString();
+		editDate = transaction.date;
+		editDescription = transaction.description ?? '';
+		showEditModal = true;
+	}
+
+	async function handleEditSubmit(event: SubmitEvent) {
+		event.preventDefault();
+		if (!editingTransaction) return;
+		const amountCents = Math.round(Number(editAmount) * 100);
+		if (!editDate || Number.isNaN(amountCents)) {
+			error = !editDate ? 'Please choose a date.' : 'Please enter a valid amount.';
+			return;
+		}
+		saving = true;
+		try {
+			await updateTransaction(accountId, editingTransaction.id, {
+				amount_cents: amountCents,
+				date: editDate,
+				description: editDescription || null
+			});
+			showEditModal = false;
+			await loadTransactions();
+		} catch (err) {
+			error = err instanceof Error ? err.message : String(err);
+		} finally {
+			saving = false;
+		}
+	}
+
+	function openMoveModal(transaction: Transaction) {
+		movingTransaction = transaction;
+		moveTargetAccountId = '';
+		showMoveModal = true;
+	}
+
+	async function handleMove(event: SubmitEvent) {
+		event.preventDefault();
+		if (!movingTransaction || !moveTargetAccountId) return;
+		moving = true;
+		try {
+			await updateTransaction(accountId, movingTransaction.id, {
+				account_id: Number(moveTargetAccountId)
+			});
+			showMoveModal = false;
+			await loadTransactions();
+		} catch (err) {
+			error = err instanceof Error ? err.message : String(err);
+		} finally {
+			moving = false;
 		}
 	}
 
@@ -133,7 +221,18 @@
 							{formatAmount(transaction.amount_cents)}
 						</td>
 						<td class="px-4 py-2 text-right">
-							<Button variant="danger" onclick={() => handleDelete(transaction.id)}>Delete</Button>
+							<RowActionsMenu
+								label="Transaction actions"
+								actions={[
+									{ label: 'Edit', onclick: () => openEditModal(transaction) },
+									{ label: 'Move', onclick: () => openMoveModal(transaction) },
+									{
+										label: 'Delete',
+										onclick: () => handleDelete(transaction.id),
+										variant: 'danger'
+									}
+								]}
+							/>
 						</td>
 					</tr>
 				{/each}
@@ -141,3 +240,42 @@
 		</Table>
 	{/if}
 </div>
+
+<Modal bind:open={showMoveModal} title="Move transaction">
+	{#if movingTransaction}
+		<form class="flex flex-col gap-4" onsubmit={handleMove}>
+			<p class="text-sm text-slate-600">
+				Move this transaction to a different account.
+			</p>
+			<Select
+				label="Account"
+				bind:value={moveTargetAccountId}
+				options={accounts
+					.filter((a) => a.id !== accountId)
+					.map((target) => ({ value: String(target.id), label: target.name }))}
+			/>
+			<div class="flex justify-end gap-2">
+				<Button variant="secondary" type="button" onclick={() => (showMoveModal = false)}>
+					Cancel
+				</Button>
+				<Button type="submit" disabled={moving || !moveTargetAccountId}>Move</Button>
+			</div>
+		</form>
+	{/if}
+</Modal>
+
+<Modal bind:open={showEditModal} title="Edit transaction">
+	{#if editingTransaction}
+		<form class="flex flex-col gap-4" onsubmit={handleEditSubmit}>
+			<Input label="Amount ($)" type="number" step="0.01" bind:value={editAmount} required />
+			<DatePicker label="Date" bind:value={editDate} />
+			<Input label="Description" bind:value={editDescription} placeholder="Optional" />
+			<div class="flex justify-end gap-2">
+				<Button variant="secondary" type="button" onclick={() => (showEditModal = false)}>
+					Cancel
+				</Button>
+				<Button type="submit" disabled={saving}>Save</Button>
+			</div>
+		</form>
+	{/if}
+</Modal>

--- a/frontend/src/routes/(app)/accounts/[id]/windfalls/+page.svelte
+++ b/frontend/src/routes/(app)/accounts/[id]/windfalls/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { page } from '$app/stores';
-	import { getAccount } from '$lib/api/accounts';
-	import { createWindfall, deleteWindfall, listWindfalls } from '$lib/api/windfalls';
+	import { getAccount, listAccounts } from '$lib/api/accounts';
+	import { createWindfall, deleteWindfall, listWindfalls, updateWindfall } from '$lib/api/windfalls';
 	import type { BankAccount, Windfall } from '$lib/api/types';
 	import { accountSuffix } from '$lib/format';
 	import AccountNav from '$lib/components/AccountNav.svelte';
@@ -9,6 +9,9 @@
 	import Card from '$lib/components/Card.svelte';
 	import DatePicker from '$lib/components/DatePicker.svelte';
 	import Input from '$lib/components/Input.svelte';
+	import Modal from '$lib/components/Modal.svelte';
+	import RowActionsMenu from '$lib/components/RowActionsMenu.svelte';
+	import Select from '$lib/components/Select.svelte';
 	import Table from '$lib/components/Table.svelte';
 	import Tooltip from '$lib/components/Tooltip.svelte';
 	import { glossaryTerms } from '$lib/glossary';
@@ -19,6 +22,7 @@
 	const accountId = $derived(Number($page.params.id));
 
 	let account = $state<BankAccount | null>(null);
+	let accounts = $state<BankAccount[]>([]);
 	let windfalls = $state<Windfall[]>([]);
 	let loading = $state(true);
 	let error = $state<string | null>(null);
@@ -28,14 +32,35 @@
 	let expectedDate = $state('');
 	let creating = $state(false);
 
-	async function load() {
+	let editingWindfall = $state<Windfall | null>(null);
+	let editName = $state('');
+	let editAmount = $state('');
+	let editExpectedDate = $state('');
+	let saving = $state(false);
+	let showEditModal = $state(false);
+
+	let movingWindfall = $state<Windfall | null>(null);
+	let moveTargetAccountId = $state('');
+	let moving = $state(false);
+	let showMoveModal = $state(false);
+
+	// Account details and the accounts list (for the move-windfall picker)
+	// only change when navigating here or moving a windfall elsewhere
+	// entirely - they don't need refetching after every create/delete,
+	// unlike windfalls itself.
+	async function loadContext() {
+		try {
+			[account, accounts] = await Promise.all([getAccount(accountId), listAccounts()]);
+		} catch (err) {
+			error = err instanceof Error ? err.message : String(err);
+		}
+	}
+
+	async function loadWindfalls() {
 		loading = true;
 		error = null;
 		try {
-			[account, windfalls] = await Promise.all([
-				getAccount(accountId),
-				listWindfalls(accountId)
-			]);
+			windfalls = await listWindfalls(accountId);
 		} catch (err) {
 			error = err instanceof Error ? err.message : String(err);
 		} finally {
@@ -43,7 +68,10 @@
 		}
 	}
 
-	onMount(load);
+	onMount(() => {
+		loadContext();
+		loadWindfalls();
+	});
 
 	async function handleCreate(event: SubmitEvent) {
 		event.preventDefault();
@@ -66,7 +94,7 @@
 			name = '';
 			amount = '';
 			expectedDate = '';
-			await load();
+			await loadWindfalls();
 		} catch (err) {
 			error = err instanceof Error ? err.message : String(err);
 		} finally {
@@ -77,9 +105,68 @@
 	async function handleDelete(windfallId: number) {
 		try {
 			await deleteWindfall(accountId, windfallId);
-			await load();
+			await loadWindfalls();
 		} catch (err) {
 			error = err instanceof Error ? err.message : String(err);
+		}
+	}
+
+	function openEditModal(windfall: Windfall) {
+		editingWindfall = windfall;
+		editName = windfall.name;
+		editAmount = (windfall.amount_cents / 100).toString();
+		editExpectedDate = windfall.expected_date;
+		showEditModal = true;
+	}
+
+	async function handleEditSubmit(event: SubmitEvent) {
+		event.preventDefault();
+		if (!editingWindfall) return;
+		const amountCents = Math.round(Number(editAmount) * 100);
+		if (!editName.trim() || !editExpectedDate || Number.isNaN(amountCents) || amountCents <= 0) {
+			error = !editExpectedDate
+				? 'Please choose an expected date.'
+				: amountCents <= 0
+					? 'Amount must be greater than zero.'
+					: 'Please fill out all fields.';
+			return;
+		}
+		saving = true;
+		try {
+			await updateWindfall(accountId, editingWindfall.id, {
+				name: editName,
+				amount_cents: amountCents,
+				expected_date: editExpectedDate
+			});
+			showEditModal = false;
+			await loadWindfalls();
+		} catch (err) {
+			error = err instanceof Error ? err.message : String(err);
+		} finally {
+			saving = false;
+		}
+	}
+
+	function openMoveModal(windfall: Windfall) {
+		movingWindfall = windfall;
+		moveTargetAccountId = '';
+		showMoveModal = true;
+	}
+
+	async function handleMove(event: SubmitEvent) {
+		event.preventDefault();
+		if (!movingWindfall || !moveTargetAccountId) return;
+		moving = true;
+		try {
+			await updateWindfall(accountId, movingWindfall.id, {
+				account_id: Number(moveTargetAccountId)
+			});
+			showMoveModal = false;
+			await loadWindfalls();
+		} catch (err) {
+			error = err instanceof Error ? err.message : String(err);
+		} finally {
+			moving = false;
 		}
 	}
 
@@ -138,7 +225,14 @@
 							{formatAmount(windfall.amount_cents)}
 						</td>
 						<td class="px-4 py-2 text-right">
-							<Button variant="danger" onclick={() => handleDelete(windfall.id)}>Delete</Button>
+							<RowActionsMenu
+								label="Windfall actions"
+								actions={[
+									{ label: 'Edit', onclick: () => openEditModal(windfall) },
+									{ label: 'Move', onclick: () => openMoveModal(windfall) },
+									{ label: 'Delete', onclick: () => handleDelete(windfall.id), variant: 'danger' }
+								]}
+							/>
 						</td>
 					</tr>
 				{/each}
@@ -146,3 +240,42 @@
 		</Table>
 	{/if}
 </div>
+
+<Modal bind:open={showMoveModal} title="Move windfall">
+	{#if movingWindfall}
+		<form class="flex flex-col gap-4" onsubmit={handleMove}>
+			<p class="text-sm text-slate-600">
+				Move <span class="font-medium text-text">{movingWindfall.name}</span> to a different account.
+			</p>
+			<Select
+				label="Account"
+				bind:value={moveTargetAccountId}
+				options={accounts
+					.filter((a) => a.id !== accountId)
+					.map((target) => ({ value: String(target.id), label: target.name }))}
+			/>
+			<div class="flex justify-end gap-2">
+				<Button variant="secondary" type="button" onclick={() => (showMoveModal = false)}>
+					Cancel
+				</Button>
+				<Button type="submit" disabled={moving || !moveTargetAccountId}>Move</Button>
+			</div>
+		</form>
+	{/if}
+</Modal>
+
+<Modal bind:open={showEditModal} title="Edit windfall">
+	{#if editingWindfall}
+		<form class="flex flex-col gap-4" onsubmit={handleEditSubmit}>
+			<Input label="Name" bind:value={editName} required />
+			<Input label="Amount ($)" type="number" step="0.01" bind:value={editAmount} required />
+			<DatePicker label="Expected date" bind:value={editExpectedDate} />
+			<div class="flex justify-end gap-2">
+				<Button variant="secondary" type="button" onclick={() => (showEditModal = false)}>
+					Cancel
+				</Button>
+				<Button type="submit" disabled={saving}>Save</Button>
+			</div>
+		</form>
+	{/if}
+</Modal>


### PR DESCRIPTION
## Summary

**Bill review flags**
- Bills whose `start_date == end_date` only ever occur once - a pattern ported from the old 'bank' app to model single expenses (e.g. "Averie's Graduation Party", $600, 6/20/2026-6/20/2026) as a recurring Bill instead of a one-off Transaction. These now get a **"One-time"** badge with a tooltip suggesting a Transaction instead.
- Bills whose `end_date` has passed are functionally dead - no forecast cycle will ever include them again - but stayed enabled indefinitely with no cron/scheduler to catch them (this app has none, by cost-first design). `list_bills` now auto-disables them lazily on read (records a `disabled` bill_event for the audit trail), and the bills page shows an **"Ended"** badge so they're easy to spot and delete during cleanup.

**Row actions menu**
- Added a shared `RowActionsMenu` (kebab "⋮" dropdown) and moved Bills' Edit/Move/Delete buttons into it. It positions itself via a body-level portal + fixed coordinates rather than relative to its row - `Table`'s `overflow-x-auto` wrapper computes `overflow-y: auto` too per the CSS overflow spec, which silently clipped a row-relative dropdown for any row near the bottom of a list.
- Transactions and Windfalls previously only supported Delete. Added Edit and Move (`account_id`) to both, backend and frontend, so all three list views (Bills/Transactions/Windfalls) now support the same Edit/Move/Delete set through the same menu.

## Test plan

- [x] Backend: 161 tests pass (8 new - auto-disable on list, no-op on future end_date, no double-flagging an already-disabled bill, move transaction/windfall to another owned account, cannot move to another user's account)
- [x] Backend: `ruff check .` clean
- [x] Frontend: `svelte-check`, `eslint`, `vitest` all clean; production build succeeds
- [x] Verified in-browser via Playwright against the docker-compose stack (dev auth bypass): badges render correctly on seeded one-time/expired/normal bills; kebab menu opens and positions correctly even on the table's last row; Edit/Move both round-trip through the API on all three pages (Bills, Transactions, Windfalls)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
