### PR TITLE
fix: pre-ping and recycle DB connections to survive Neon idle timeouts

### DIFF
--- a/backend/src/core/database.py
+++ b/backend/src/core/database.py
@@ -3,7 +3,17 @@ from sqlalchemy.orm import DeclarativeBase
 
 from src.core.config import settings
 
-engine = create_async_engine(settings.database_url_readwrite)
+# pool_pre_ping + pool_recycle: the engine is created once at module scope
+# and its pooled connections survive across warm Lambda invocations. Neon
+# closes idle connections well under our recycle window, so without these a
+# request landing on a container whose pooled connection went stale gets
+# `asyncpg.exceptions.InterfaceError: connection is closed` instead of a
+# transparent reconnect.
+engine = create_async_engine(
+    settings.database_url_readwrite,
+    pool_pre_ping=True,
+    pool_recycle=270,
+)
 async_session = async_sessionmaker(engine, expire_on_commit=False)
 
 

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -1,0 +1,15 @@
+from src.core.database import engine
+
+
+def test_engine_pre_pings_connections_before_reuse():
+    # Without this, a pooled connection that Neon closed server-side while a
+    # Lambda container sat idle between invocations gets handed back out
+    # as-is, and the next query fails with asyncpg's InterfaceError instead
+    # of transparently reconnecting.
+    assert engine.pool._pre_ping is True
+
+
+def test_engine_recycles_connections_before_neon_idle_timeout():
+    # Must stay under whatever idle-connection timeout Neon enforces so a
+    # pooled connection is proactively replaced before Neon closes it first.
+    assert 0 < engine.pool._recycle <= 270


### PR DESCRIPTION
## Summary
- Production has been intermittently returning 500s (confirmed via CloudWatch: `asyncpg.exceptions._base.InterfaceError: connection is closed`, clustered in low-traffic overnight hours)
- Root cause: `engine` in `backend/src/core/database.py` is created once at module scope, and its pooled connections persist across warm Lambda container reuses. Neon closes idle connections server-side before our pool would otherwise recycle them, so the next request to reuse a stale pooled connection fails outright instead of reconnecting.
- Fix: `pool_pre_ping=True` (validates a connection is alive before handing it out, transparently reconnecting if not) + `pool_recycle=270` (proactively replaces connections before Neon's idle timeout)

## Test plan
- [x] Added `backend/tests/test_database.py` asserting the engine is configured with `pool_pre_ping=True` and a `pool_recycle` under 270s
- [x] Full backend suite passes (163 passed)
- [ ] After merge/deploy, watch the `5XXError` API Gateway metric and `/aws/lambda/tally-backend` logs for `InterfaceError: connection is closed` to confirm it stops recurring

🤖 Generated with [Claude Code](https://claude.com/claude-code)