### PR TITLE
feat: CSV import/export with reconciliation for Bills, Transactions, and Windfalls

### DIFF
--- a/backend/alembic/versions/b88c09336fb3_add_enabled_to_windfalls.py
+++ b/backend/alembic/versions/b88c09336fb3_add_enabled_to_windfalls.py
@@ -1,0 +1,31 @@
+"""add enabled to windfalls
+
+Revision ID: b88c09336fb3
+Revises: 937249cdc4e0
+Create Date: 2026-07-15 14:52:16.947239
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b88c09336fb3'
+down_revision: Union[str, Sequence[str], None] = '937249cdc4e0'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        'windfalls',
+        sa.Column('enabled', sa.Boolean(), server_default=sa.text('true'), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('windfalls', 'enabled')

--- a/backend/src/api/bills.py
+++ b/backend/src/api/bills.py
@@ -6,13 +6,22 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.api.deps import get_bank_account_or_404, get_current_db_user, get_owned_bank_account
-from src.bill_events import TRACKED_BILL_FIELDS, created_event, expired_event, update_events
-from src.bills_csv import bills_to_csv, parse_csv_rows
+from src.bill_events import TRACKED_BILL_FIELDS, created_event, disabled_event, update_events
+from src.bills_csv import bills_to_csv, parse_csv_rows, reconcile_bills
 from src.core.database import get_db
 from src.forecast import ForecastBill, ForecastCycleOverride, build_bill_history, last_cycle_end
 from src.forecast.bill import validate_recurrence_config
 from src.models import BankAccount, Bill, BillEvent, CycleOverride, CycleType, RecurrenceType, User
-from src.schemas.bill import BillCreate, BillRead, BillUpdate
+from src.schemas.bill import (
+    BillCreate,
+    BillImportAmbiguous,
+    BillImportCommitRequest,
+    BillImportCommitResponse,
+    BillImportPreview,
+    BillImportUpdate,
+    BillRead,
+    BillUpdate,
+)
 from src.schemas.bill_event import BillEventCycleCount, BillEventCycleCountsResponse, BillEventListResponse
 from src.schemas.bill_history import BillHistoryEntry, BillHistoryResponse
 
@@ -55,7 +64,7 @@ async def _auto_disable_expired(db: AsyncSession, bills: list[Bill]) -> None:
         return
     for bill in expired:
         bill.enabled = False
-    db.add_all(expired_event(bill) for bill in expired)
+    db.add_all(disabled_event(bill) for bill in expired)
     await db.commit()
     # updated_at's onupdate=func.now() is server-computed - without a
     # refresh, the response would try to lazy-load it outside any awaited
@@ -105,12 +114,20 @@ async def export_bills(
     )
 
 
-@router.post("/import", response_model=list[BillRead], status_code=status.HTTP_201_CREATED)
-async def import_bills(
+def _describe_ambiguous_bill(parsed: BillCreate, matches: list[Bill]) -> str:
+    return (
+        f'"{parsed.name}" (${parsed.amount_cents / 100:.2f}, {parsed.recurrence_type.value}, '
+        f"starting {parsed.start_date}) matches {len(matches)} existing bills - resolve manually "
+        "before reimporting."
+    )
+
+
+@router.post("/import/preview", response_model=BillImportPreview)
+async def preview_bill_import(
     file: UploadFile,
     db: AsyncSession = Depends(get_db),
     account: BankAccount = Depends(get_owned_bank_account),
-) -> list[Bill]:
+) -> BillImportPreview:
     csv_text = (await file.read()).decode("utf-8-sig")  # -sig strips an Excel-added BOM
     parsed_bills, errors = parse_csv_rows(csv_text)
     if errors:
@@ -119,14 +136,81 @@ async def import_bills(
             detail={"errors": [{"row": e.row, "message": e.message} for e in errors]},
         )
 
-    bills = [Bill(account_id=account.id, **payload.model_dump()) for payload in parsed_bills]
-    db.add_all(bills)
+    result = await db.execute(select(Bill).where(Bill.account_id == account.id))
+    existing_bills = list(result.scalars().all())
+    reconciled = reconcile_bills(existing_bills, parsed_bills)
+
+    return BillImportPreview(
+        new=reconciled.new,
+        updated=[
+            BillImportUpdate(id=match.existing.id, fields=match.parsed) for match in reconciled.updated
+        ],
+        unchanged_count=len(reconciled.unchanged),
+        ambiguous=[
+            BillImportAmbiguous(message=_describe_ambiguous_bill(a.parsed, a.matches))
+            for a in reconciled.ambiguous
+        ],
+        omitted=[bill for bill in reconciled.omitted if bill.enabled],
+        errors=[],
+    )
+
+
+@router.post("/import/commit", response_model=BillImportCommitResponse)
+async def commit_bill_import(
+    payload: BillImportCommitRequest,
+    db: AsyncSession = Depends(get_db),
+    account: BankAccount = Depends(get_owned_bank_account),
+) -> BillImportCommitResponse:
+    for item in payload.new:
+        _validate_or_422(item.recurrence_type, item.recurrence_config)
+    for item in payload.updated:
+        _validate_or_422(item.fields.recurrence_type, item.fields.recurrence_config)
+
+    created_bills = [Bill(account_id=account.id, **item.model_dump()) for item in payload.new]
+    db.add_all(created_bills)
     await db.flush()  # assigns each bill.id, needed for the events' FK
-    db.add_all(created_event(bill) for bill in bills)
-    ids = [bill.id for bill in bills]
+    db.add_all(created_event(bill) for bill in created_bills)
+
+    updated_bills: list[Bill] = []
+    if payload.updated:
+        ids = [item.id for item in payload.updated]
+        result = await db.execute(
+            select(Bill).where(Bill.id.in_(ids), Bill.account_id == account.id)
+        )
+        bills_by_id = {bill.id: bill for bill in result.scalars().all()}
+        for item in payload.updated:
+            bill = bills_by_id.get(item.id)
+            if bill is None:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND, detail=f"Bill {item.id} not found"
+                )
+            before = {field: getattr(bill, field) for field in [*TRACKED_BILL_FIELDS, "notes", "enabled"]}
+            update_data = item.fields.model_dump()
+            for field, value in update_data.items():
+                setattr(bill, field, value)
+            db.add_all(update_events(bill, update_data, before))
+            updated_bills.append(bill)
+
+    disabled_count = 0
+    if payload.omitted_ids:
+        result = await db.execute(
+            select(Bill).where(
+                Bill.id.in_(payload.omitted_ids), Bill.account_id == account.id, Bill.enabled.is_(True)
+            )
+        )
+        to_disable = list(result.scalars().all())
+        for bill in to_disable:
+            bill.enabled = False
+        db.add_all(disabled_event(bill) for bill in to_disable)
+        disabled_count = len(to_disable)
+
     await db.commit()
-    result = await db.execute(select(Bill).where(Bill.id.in_(ids)).order_by(Bill.id))
-    return list(result.scalars().all())
+    for bill in [*created_bills, *updated_bills]:
+        await db.refresh(bill)
+
+    return BillImportCommitResponse(
+        created=created_bills, updated=updated_bills, disabled_count=disabled_count
+    )
 
 
 @router.patch("/{bill_id}", response_model=BillRead)

--- a/backend/src/api/dashboard.py
+++ b/backend/src/api/dashboard.py
@@ -82,6 +82,7 @@ async def _current_cycle_summary(db: AsyncSession, account: BankAccount, today: 
     windfalls_result = await db.execute(
         select(Windfall).where(
             Windfall.account_id == account.id,
+            Windfall.enabled.is_(True),
             Windfall.expected_date >= anchor,
             Windfall.expected_date <= cycle_end,
         )

--- a/backend/src/api/forecast.py
+++ b/backend/src/api/forecast.py
@@ -77,6 +77,7 @@ async def compute_forecast(
     windfalls_result = await db.execute(
         select(Windfall).where(
             Windfall.account_id == account.id,
+            Windfall.enabled.is_(True),
             Windfall.expected_date >= payload.start_date,
             Windfall.expected_date <= query_end_date,
         )

--- a/backend/src/api/transactions.py
+++ b/backend/src/api/transactions.py
@@ -1,11 +1,23 @@
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, status
+from fastapi.responses import Response
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.api.deps import get_bank_account_or_404, get_current_db_user, get_owned_bank_account
 from src.core.database import get_db
 from src.models import BankAccount, Bill, Transaction, User
-from src.schemas.transaction import TransactionCreate, TransactionRead, TransactionUpdate
+from src.schemas.transaction import (
+    TransactionCreate,
+    TransactionImportAmbiguous,
+    TransactionImportCommitRequest,
+    TransactionImportCommitResponse,
+    TransactionImportPreview,
+    TransactionImportRowIssue,
+    TransactionImportUpdate,
+    TransactionRead,
+    TransactionUpdate,
+)
+from src.transactions_csv import parse_csv_rows, reconcile_transactions, transactions_to_csv
 
 router = APIRouter(prefix="/api/v1/accounts/{account_id}/transactions", tags=["transactions"])
 
@@ -75,6 +87,122 @@ async def create_transaction(
     await db.commit()
     await db.refresh(transaction)
     return transaction
+
+
+@router.get("/export")
+async def export_transactions(
+    db: AsyncSession = Depends(get_db),
+    account: BankAccount = Depends(get_owned_bank_account),
+) -> Response:
+    transactions_result = await db.execute(
+        select(Transaction).where(Transaction.account_id == account.id)
+    )
+    bills_result = await db.execute(select(Bill).where(Bill.account_id == account.id))
+    csv_text = transactions_to_csv(
+        list(transactions_result.scalars().all()), list(bills_result.scalars().all())
+    )
+    return Response(
+        content=csv_text,
+        media_type="text/csv",
+        headers={"Content-Disposition": f'attachment; filename="transactions-{account.id}.csv"'},
+    )
+
+
+def _describe_ambiguous_transaction(parsed: TransactionCreate) -> str:
+    return (
+        f"${parsed.amount_cents / 100:.2f} on {parsed.date}"
+        f'{f" ({parsed.description})" if parsed.description else ""} matches more than one '
+        "existing transaction - resolve manually before reimporting."
+    )
+
+
+@router.post("/import/preview", response_model=TransactionImportPreview)
+async def preview_transaction_import(
+    file: UploadFile,
+    db: AsyncSession = Depends(get_db),
+    account: BankAccount = Depends(get_owned_bank_account),
+) -> TransactionImportPreview:
+    csv_text = (await file.read()).decode("utf-8-sig")  # -sig strips an Excel-added BOM
+    bills_result = await db.execute(select(Bill).where(Bill.account_id == account.id))
+    bills = list(bills_result.scalars().all())
+    parsed_transactions, errors, warnings = parse_csv_rows(csv_text, bills)
+    if errors:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={"errors": [{"row": e.row, "message": e.message} for e in errors]},
+        )
+
+    transactions_result = await db.execute(
+        select(Transaction).where(Transaction.account_id == account.id)
+    )
+    existing_transactions = list(transactions_result.scalars().all())
+    reconciled = reconcile_transactions(existing_transactions, parsed_transactions)
+
+    return TransactionImportPreview(
+        new=reconciled.new,
+        updated=[
+            TransactionImportUpdate(id=match.existing.id, fields=match.parsed)
+            for match in reconciled.updated
+        ],
+        unchanged_count=len(reconciled.unchanged),
+        ambiguous=[
+            TransactionImportAmbiguous(message=_describe_ambiguous_transaction(a.parsed))
+            for a in reconciled.ambiguous
+        ],
+        omitted=reconciled.omitted,
+        warnings=[TransactionImportRowIssue(row=w.row, message=w.message) for w in warnings],
+        errors=[],
+    )
+
+
+@router.post("/import/commit", response_model=TransactionImportCommitResponse)
+async def commit_transaction_import(
+    payload: TransactionImportCommitRequest,
+    db: AsyncSession = Depends(get_db),
+    account: BankAccount = Depends(get_owned_bank_account),
+) -> TransactionImportCommitResponse:
+    for item in payload.new:
+        await _validate_bill_id(item.bill_id, account.id, db)
+    for item in payload.updated:
+        await _validate_bill_id(item.fields.bill_id, account.id, db)
+
+    created = [Transaction(account_id=account.id, **item.model_dump()) for item in payload.new]
+    db.add_all(created)
+
+    updated: list[Transaction] = []
+    if payload.updated:
+        ids = [item.id for item in payload.updated]
+        result = await db.execute(
+            select(Transaction).where(Transaction.id.in_(ids), Transaction.account_id == account.id)
+        )
+        transactions_by_id = {transaction.id: transaction for transaction in result.scalars().all()}
+        for item in payload.updated:
+            transaction = transactions_by_id.get(item.id)
+            if transaction is None:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND, detail=f"Transaction {item.id} not found"
+                )
+            for field, value in item.fields.model_dump().items():
+                setattr(transaction, field, value)
+            updated.append(transaction)
+
+    deleted_count = 0
+    if payload.omitted_ids:
+        result = await db.execute(
+            select(Transaction).where(
+                Transaction.id.in_(payload.omitted_ids), Transaction.account_id == account.id
+            )
+        )
+        to_delete = list(result.scalars().all())
+        for transaction in to_delete:
+            await db.delete(transaction)
+        deleted_count = len(to_delete)
+
+    await db.commit()
+    for transaction in [*created, *updated]:
+        await db.refresh(transaction)
+
+    return TransactionImportCommitResponse(created=created, updated=updated, deleted_count=deleted_count)
 
 
 @router.patch("/{transaction_id}", response_model=TransactionRead)

--- a/backend/src/api/windfalls.py
+++ b/backend/src/api/windfalls.py
@@ -1,15 +1,26 @@
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, status
+from fastapi.responses import Response
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.api.deps import get_bank_account_or_404, get_current_db_user, get_owned_bank_account
 from src.core.database import get_db
 from src.models import BankAccount, User, Windfall
-from src.schemas.windfall import WindfallCreate, WindfallRead, WindfallUpdate
+from src.schemas.windfall import (
+    WindfallCreate,
+    WindfallImportAmbiguous,
+    WindfallImportCommitRequest,
+    WindfallImportCommitResponse,
+    WindfallImportPreview,
+    WindfallImportUpdate,
+    WindfallRead,
+    WindfallUpdate,
+)
+from src.windfalls_csv import parse_csv_rows, reconcile_windfalls, windfalls_to_csv
 
 router = APIRouter(prefix="/api/v1/accounts/{account_id}/windfalls", tags=["windfalls"])
 
-_NON_NULLABLE_UPDATE_FIELDS = ("name", "amount_cents", "expected_date")
+_NON_NULLABLE_UPDATE_FIELDS = ("name", "amount_cents", "expected_date", "enabled")
 
 
 def _reject_explicit_nulls(update_data: dict) -> None:
@@ -63,6 +74,108 @@ async def create_windfall(
     await db.commit()
     await db.refresh(windfall)
     return windfall
+
+
+@router.get("/export")
+async def export_windfalls(
+    db: AsyncSession = Depends(get_db),
+    account: BankAccount = Depends(get_owned_bank_account),
+) -> Response:
+    result = await db.execute(select(Windfall).where(Windfall.account_id == account.id))
+    csv_text = windfalls_to_csv(list(result.scalars().all()))
+    return Response(
+        content=csv_text,
+        media_type="text/csv",
+        headers={"Content-Disposition": f'attachment; filename="windfalls-{account.id}.csv"'},
+    )
+
+
+def _describe_ambiguous_windfall(parsed: WindfallCreate, matches: list[Windfall]) -> str:
+    return (
+        f'"{parsed.name}" (${parsed.amount_cents / 100:.2f}, expected {parsed.expected_date}) '
+        f"matches {len(matches)} existing windfalls - resolve manually before reimporting."
+    )
+
+
+@router.post("/import/preview", response_model=WindfallImportPreview)
+async def preview_windfall_import(
+    file: UploadFile,
+    db: AsyncSession = Depends(get_db),
+    account: BankAccount = Depends(get_owned_bank_account),
+) -> WindfallImportPreview:
+    csv_text = (await file.read()).decode("utf-8-sig")  # -sig strips an Excel-added BOM
+    parsed_windfalls, errors = parse_csv_rows(csv_text)
+    if errors:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={"errors": [{"row": e.row, "message": e.message} for e in errors]},
+        )
+
+    result = await db.execute(select(Windfall).where(Windfall.account_id == account.id))
+    existing_windfalls = list(result.scalars().all())
+    reconciled = reconcile_windfalls(existing_windfalls, parsed_windfalls)
+
+    return WindfallImportPreview(
+        new=reconciled.new,
+        updated=[
+            WindfallImportUpdate(id=match.existing.id, fields=match.parsed)
+            for match in reconciled.updated
+        ],
+        unchanged_count=len(reconciled.unchanged),
+        ambiguous=[
+            WindfallImportAmbiguous(message=_describe_ambiguous_windfall(a.parsed, a.matches))
+            for a in reconciled.ambiguous
+        ],
+        omitted=[windfall for windfall in reconciled.omitted if windfall.enabled],
+        errors=[],
+    )
+
+
+@router.post("/import/commit", response_model=WindfallImportCommitResponse)
+async def commit_windfall_import(
+    payload: WindfallImportCommitRequest,
+    db: AsyncSession = Depends(get_db),
+    account: BankAccount = Depends(get_owned_bank_account),
+) -> WindfallImportCommitResponse:
+    created = [Windfall(account_id=account.id, **item.model_dump()) for item in payload.new]
+    db.add_all(created)
+
+    updated: list[Windfall] = []
+    if payload.updated:
+        ids = [item.id for item in payload.updated]
+        result = await db.execute(
+            select(Windfall).where(Windfall.id.in_(ids), Windfall.account_id == account.id)
+        )
+        windfalls_by_id = {windfall.id: windfall for windfall in result.scalars().all()}
+        for item in payload.updated:
+            windfall = windfalls_by_id.get(item.id)
+            if windfall is None:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND, detail=f"Windfall {item.id} not found"
+                )
+            for field, value in item.fields.model_dump().items():
+                setattr(windfall, field, value)
+            updated.append(windfall)
+
+    disabled_count = 0
+    if payload.omitted_ids:
+        result = await db.execute(
+            select(Windfall).where(
+                Windfall.id.in_(payload.omitted_ids),
+                Windfall.account_id == account.id,
+                Windfall.enabled.is_(True),
+            )
+        )
+        to_disable = list(result.scalars().all())
+        for windfall in to_disable:
+            windfall.enabled = False
+        disabled_count = len(to_disable)
+
+    await db.commit()
+    for windfall in [*created, *updated]:
+        await db.refresh(windfall)
+
+    return WindfallImportCommitResponse(created=created, updated=updated, disabled_count=disabled_count)
 
 
 @router.patch("/{windfall_id}", response_model=WindfallRead)

--- a/backend/src/bill_events.py
+++ b/backend/src/bill_events.py
@@ -40,12 +40,13 @@ def created_event(bill: Bill) -> BillEvent:
     )
 
 
-def expired_event(bill: Bill) -> BillEvent:
-    """Bill auto-disabled because its end_date has passed (see
-    _auto_disable_expired in src/api/bills.py) - a plain DISABLED event, same
-    as a manual toggle, since there's no per-field diff to show and the
-    timeline already labels every DISABLED event the same way regardless of
-    cause.
+def disabled_event(bill: Bill) -> BillEvent:
+    """A plain DISABLED event with no per-field diff - used wherever a bill
+    is disabled other than through a user-initiated PATCH (which goes
+    through update_events instead): auto-disabled because its end_date has
+    passed (_auto_disable_expired in src/api/bills.py), or disabled because
+    a CSV reimport omitted it (src/api/bills.py's import/commit). The
+    timeline labels every DISABLED event the same way regardless of cause.
     """
     return BillEvent(account_id=bill.account_id, bill_id=bill.id, event_type=BillEventType.DISABLED)
 

--- a/backend/src/bills_csv.py
+++ b/backend/src/bills_csv.py
@@ -2,14 +2,24 @@ from __future__ import annotations
 
 import csv
 import io
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import date
 
 from pydantic import ValidationError
 
+from src.csv_match import ReconcileResult, reconcile
 from src.forecast.bill import validate_recurrence_config
 from src.models.bill import Bill, RecurrenceType
 from src.schemas.bill import BillCreate
+
+# Fields compared (via getattr, so must exist under these names on both Bill
+# and BillCreate) once a row's match key resolves to exactly one existing
+# bill, to decide "updated" vs "unchanged". name/amount_cents/
+# recurrence_type/start_date are the match key itself (see _bill_key) so are
+# excluded here - see the "known limitation" this implies in the roadmap:
+# changing a key field looks like a new bill, not an edit of the old one.
+BILL_DIFF_FIELDS = ["recurrence_config", "end_date", "enabled", "notes"]
 
 CSV_COLUMNS = [
     "name",
@@ -161,3 +171,17 @@ def parse_csv_rows(csv_text: str) -> tuple[list[BillCreate], list[RowError]]:
             errors.append(RowError(row=row_number, message=str(exc)))
 
     return bills, errors
+
+
+def _bill_key(row: Bill | BillCreate) -> tuple:
+    return (row.name.strip().lower(), row.amount_cents, row.recurrence_type, row.start_date)
+
+
+def reconcile_bills(
+    existing: Sequence[Bill], parsed: Sequence[BillCreate]
+) -> ReconcileResult[Bill, BillCreate]:
+    """Matches parsed CSV rows against an account's current bills (both
+    enabled and disabled - a CSV row matching a disabled bill with
+    enabled=true in BILL_DIFF_FIELDS re-enables it via the normal "updated"
+    path, rather than needing special-casing here)."""
+    return reconcile(existing, parsed, key_fn=_bill_key, diff_fields=BILL_DIFF_FIELDS)

--- a/backend/src/csv_match.py
+++ b/backend/src/csv_match.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Hashable, Sequence
+from dataclasses import dataclass
+
+
+@dataclass
+class Updated[Existing, Parsed]:
+    existing: Existing
+    parsed: Parsed
+
+
+@dataclass
+class Ambiguous[Parsed]:
+    parsed: Parsed
+    matches: list  # the >1 existing rows this row's key collided with
+
+
+@dataclass
+class ReconcileResult[Existing, Parsed]:
+    new: list[Parsed]
+    updated: list[Updated[Existing, Parsed]]
+    unchanged: list[Existing]
+    ambiguous: list[Ambiguous[Parsed]]
+    # Existing rows whose key never appeared in any parsed CSV row. Callers
+    # that have a soft-delete concept (Bill.enabled, Windfall.enabled) should
+    # filter this to already-enabled rows before acting on it - an
+    # already-disabled row reappearing here would just be a no-op re-disable.
+    omitted: list[Existing]
+
+
+def reconcile[Existing, Parsed](
+    existing_rows: Sequence[Existing],
+    parsed_rows: Sequence[Parsed],
+    key_fn: Callable[[Existing | Parsed], Hashable],
+    diff_fields: Sequence[str],
+) -> ReconcileResult[Existing, Parsed]:
+    """Buckets each parsed CSV row against an account's current rows by a
+    fuzzy field-match key (`key_fn`) - there's no id column round-tripped
+    through the CSV, so "is this row the same as that one" is inferred
+    entirely from field values. `diff_fields` are compared via getattr to
+    decide "updated" vs "unchanged" once a row's key resolves to exactly one
+    existing row.
+
+    A CSV with two rows that key to the same value (e.g. a duplicated line)
+    will each independently match the same existing row - harmless (the
+    second update is a redundant no-op), not guarded against here.
+    """
+    by_key: dict[Hashable, list[Existing]] = {}
+    for row in existing_rows:
+        by_key.setdefault(key_fn(row), []).append(row)
+
+    matched_keys: set[Hashable] = set()
+    new: list[Parsed] = []
+    updated: list[Updated[Existing, Parsed]] = []
+    unchanged: list[Existing] = []
+    ambiguous: list[Ambiguous[Parsed]] = []
+
+    for parsed in parsed_rows:
+        key = key_fn(parsed)
+        matches = by_key.get(key, [])
+        if not matches:
+            new.append(parsed)
+            continue
+
+        matched_keys.add(key)
+        if len(matches) > 1:
+            ambiguous.append(Ambiguous(parsed=parsed, matches=matches))
+            continue
+
+        existing = matches[0]
+        if any(getattr(existing, field) != getattr(parsed, field) for field in diff_fields):
+            updated.append(Updated(existing=existing, parsed=parsed))
+        else:
+            unchanged.append(existing)
+
+    omitted = [row for key, rows in by_key.items() if key not in matched_keys for row in rows]
+
+    return ReconcileResult(
+        new=new, updated=updated, unchanged=unchanged, ambiguous=ambiguous, omitted=omitted
+    )

--- a/backend/src/models/windfall.py
+++ b/backend/src/models/windfall.py
@@ -1,7 +1,7 @@
 from datetime import date, datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import BigInteger, Date, DateTime, ForeignKey, String, func
+from sqlalchemy import BigInteger, Boolean, Date, DateTime, ForeignKey, String, func, true
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.core.database import Base
@@ -21,6 +21,10 @@ class Windfall(Base):
     amount_cents: Mapped[int] = mapped_column(BigInteger)
     expected_date: Mapped[date] = mapped_column(Date)
     name: Mapped[str] = mapped_column(String(255))
+    # Soft-delete flag, same purpose as Bill.enabled - lets CSV import "omit
+    # this row" mean disable (cycle_overrides survive) rather than a hard
+    # delete that would cascade them away.
+    enabled: Mapped[bool] = mapped_column(Boolean, default=True, server_default=true())
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )

--- a/backend/src/schemas/bill.py
+++ b/backend/src/schemas/bill.py
@@ -47,3 +47,45 @@ class BillRead(BaseModel):
     notes: str | None
     created_at: datetime
     updated_at: datetime
+
+
+class BillImportRowIssue(BaseModel):
+    row: int
+    message: str
+
+
+class BillImportAmbiguous(BaseModel):
+    # No row number - this describes a match collision found during
+    # reconciliation (a CSV row's key matched more than one existing bill),
+    # not a single malformed CSV row.
+    message: str
+
+
+class BillImportUpdate(BaseModel):
+    id: int
+    fields: BillCreate
+
+
+class BillImportPreview(BaseModel):
+    new: list[BillCreate]
+    updated: list[BillImportUpdate]
+    unchanged_count: int
+    ambiguous: list[BillImportAmbiguous]
+    # Currently-enabled bills that will be disabled (not deleted - see
+    # bill_events/bill_history) if this preview is committed.
+    omitted: list[BillRead]
+    errors: list[BillImportRowIssue]
+
+
+class BillImportCommitRequest(BaseModel):
+    # Echoes the shape BillImportPreview returned - the client sends back
+    # exactly what it wants applied, not the original CSV file.
+    new: list[BillCreate]
+    updated: list[BillImportUpdate]
+    omitted_ids: list[int]
+
+
+class BillImportCommitResponse(BaseModel):
+    created: list[BillRead]
+    updated: list[BillRead]
+    disabled_count: int

--- a/backend/src/schemas/transaction.py
+++ b/backend/src/schemas/transaction.py
@@ -39,3 +39,47 @@ class TransactionRead(BaseModel):
     date: date_
     description: str | None
     created_at: datetime
+
+
+class TransactionImportRowIssue(BaseModel):
+    row: int
+    message: str
+
+
+class TransactionImportAmbiguous(BaseModel):
+    # No row number - describes a match collision found during
+    # reconciliation, not a single malformed CSV row.
+    message: str
+
+
+class TransactionImportUpdate(BaseModel):
+    id: int
+    fields: TransactionCreate
+
+
+class TransactionImportPreview(BaseModel):
+    new: list[TransactionCreate]
+    updated: list[TransactionImportUpdate]
+    unchanged_count: int
+    ambiguous: list[TransactionImportAmbiguous]
+    # Existing transactions that will be *permanently deleted* if this
+    # preview is committed - unlike Bills/Windfalls, Transaction has no
+    # soft-delete flag and nothing references transactions.id, so omission
+    # here means a real, irreversible DELETE.
+    omitted: list[TransactionRead]
+    # bill_name didn't resolve to exactly one bill on this account - the row
+    # still imports, just unlinked (bill_id null).
+    warnings: list[TransactionImportRowIssue]
+    errors: list[TransactionImportRowIssue]
+
+
+class TransactionImportCommitRequest(BaseModel):
+    new: list[TransactionCreate]
+    updated: list[TransactionImportUpdate]
+    omitted_ids: list[int]
+
+
+class TransactionImportCommitResponse(BaseModel):
+    created: list[TransactionRead]
+    updated: list[TransactionRead]
+    deleted_count: int

--- a/backend/src/schemas/windfall.py
+++ b/backend/src/schemas/windfall.py
@@ -8,12 +8,14 @@ class WindfallCreate(BaseModel):
     # Always positive - a windfall is income by definition.
     amount_cents: int = Field(gt=0)
     expected_date: date
+    enabled: bool = True
 
 
 class WindfallUpdate(BaseModel):
     name: str | None = None
     amount_cents: int | None = Field(default=None, gt=0)
     expected_date: date | None = None
+    enabled: bool | None = None
     account_id: int | None = None
 
 
@@ -25,4 +27,44 @@ class WindfallRead(BaseModel):
     name: str
     amount_cents: int
     expected_date: date
+    enabled: bool
     created_at: datetime
+
+
+class WindfallImportRowIssue(BaseModel):
+    row: int
+    message: str
+
+
+class WindfallImportAmbiguous(BaseModel):
+    # No row number - describes a match collision found during
+    # reconciliation, not a single malformed CSV row.
+    message: str
+
+
+class WindfallImportUpdate(BaseModel):
+    id: int
+    fields: WindfallCreate
+
+
+class WindfallImportPreview(BaseModel):
+    new: list[WindfallCreate]
+    updated: list[WindfallImportUpdate]
+    unchanged_count: int
+    ambiguous: list[WindfallImportAmbiguous]
+    # Currently-enabled windfalls that will be disabled (not deleted - see
+    # cycle_overrides) if this preview is committed.
+    omitted: list[WindfallRead]
+    errors: list[WindfallImportRowIssue]
+
+
+class WindfallImportCommitRequest(BaseModel):
+    new: list[WindfallCreate]
+    updated: list[WindfallImportUpdate]
+    omitted_ids: list[int]
+
+
+class WindfallImportCommitResponse(BaseModel):
+    created: list[WindfallRead]
+    updated: list[WindfallRead]
+    disabled_count: int

--- a/backend/src/transactions_csv.py
+++ b/backend/src/transactions_csv.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import csv
+import io
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import date
+
+from pydantic import ValidationError
+
+from src.csv_match import ReconcileResult, reconcile
+from src.models.bill import Bill
+from src.models.transaction import Transaction
+from src.schemas.transaction import TransactionCreate
+
+CSV_COLUMNS = ["date", "amount", "description", "bill_name"]
+
+# The only diffable field once a row's match key (date, amount_cents,
+# description) resolves to exactly one existing transaction - those three
+# key fields are effectively the whole entity already, so bill_id (the
+# name-resolved link, see _resolve_bill_id) is the one thing reimporting can
+# actually change.
+TRANSACTION_DIFF_FIELDS = ["bill_id"]
+
+
+@dataclass
+class RowError:
+    row: int  # 1-indexed, counting the header as row 1 (so row 2 is the first data row)
+    message: str
+
+
+@dataclass
+class RowWarning:
+    row: int
+    message: str
+
+
+def transaction_to_csv_row(transaction: Transaction, bill_name_by_id: dict[int, str]) -> dict:
+    return {
+        "date": transaction.date.isoformat(),
+        "amount": f"{transaction.amount_cents / 100:.2f}",
+        "description": transaction.description or "",
+        "bill_name": bill_name_by_id.get(transaction.bill_id, "") if transaction.bill_id else "",
+    }
+
+
+def transactions_to_csv(transactions: list[Transaction], bills: Sequence[Bill]) -> str:
+    bill_name_by_id = {bill.id: bill.name for bill in bills}
+    buffer = io.StringIO()
+    writer = csv.DictWriter(buffer, fieldnames=CSV_COLUMNS)
+    writer.writeheader()
+    for transaction in transactions:
+        writer.writerow(transaction_to_csv_row(transaction, bill_name_by_id))
+    return buffer.getvalue()
+
+
+def _parse_amount_cents(raw: str) -> int:
+    return round(float(raw) * 100)
+
+
+def _field(row: dict, key: str) -> str:
+    # csv.DictReader sets missing trailing fields to None (restval), not an
+    # absent key - row.get(key, "") only covers a truly absent key, so a
+    # short row would otherwise hit `.strip()` on None and raise
+    # AttributeError instead of a clean per-row ValueError.
+    return (row.get(key) or "").strip()
+
+
+def _resolve_bill_id(bill_name: str, bills_by_name: dict[str, list[Bill]]) -> tuple[int | None, str | None]:
+    """Returns (bill_id, warning) - bill_id is None whenever the name didn't
+    resolve to exactly one bill on this account; the warning explains why so
+    the row can still import (unlinked) instead of hard-failing."""
+    if not bill_name:
+        return None, None
+    matches = bills_by_name.get(bill_name.lower(), [])
+    if len(matches) == 1:
+        return matches[0].id, None
+    if len(matches) == 0:
+        return None, f'No bill named "{bill_name}" - imported unlinked.'
+    return None, f'Multiple bills named "{bill_name}" - imported unlinked.'
+
+
+def _parse_row(
+    row: dict, bills_by_name: dict[str, list[Bill]]
+) -> tuple[TransactionCreate, str | None]:
+    amount_raw = _field(row, "amount")
+    if not amount_raw:
+        raise ValueError("amount is required")
+    amount_cents = _parse_amount_cents(amount_raw)
+
+    date_raw = _field(row, "date")
+    if not date_raw:
+        raise ValueError("date is required")
+    txn_date = date.fromisoformat(date_raw)
+
+    description = _field(row, "description") or None
+    bill_id, warning = _resolve_bill_id(_field(row, "bill_name"), bills_by_name)
+
+    transaction = TransactionCreate(
+        amount_cents=amount_cents, date=txn_date, description=description, bill_id=bill_id
+    )
+    return transaction, warning
+
+
+def parse_csv_rows(
+    csv_text: str, bills: Sequence[Bill]
+) -> tuple[list[TransactionCreate], list[RowError], list[RowWarning]]:
+    """All-or-nothing on hard errors: every row must parse before any is
+    returned as importable. Ambiguous/missing bill-name links are soft
+    warnings, not errors - the row still imports, just unlinked."""
+    bills_by_name: dict[str, list[Bill]] = {}
+    for bill in bills:
+        bills_by_name.setdefault(bill.name.strip().lower(), []).append(bill)
+
+    reader = csv.DictReader(io.StringIO(csv_text))
+    transactions: list[TransactionCreate] = []
+    errors: list[RowError] = []
+    warnings: list[RowWarning] = []
+
+    for row_number, row in enumerate(reader, start=2):  # row 1 is the header
+        try:
+            transaction, warning = _parse_row(row, bills_by_name)
+        except (ValueError, TypeError, ValidationError) as exc:
+            errors.append(RowError(row=row_number, message=str(exc)))
+            continue
+        transactions.append(transaction)
+        if warning:
+            warnings.append(RowWarning(row=row_number, message=warning))
+
+    return transactions, errors, warnings
+
+
+def _transaction_key(row: Transaction | TransactionCreate) -> tuple:
+    return (row.date, row.amount_cents, row.description or "")
+
+
+def reconcile_transactions(
+    existing: Sequence[Transaction], parsed: Sequence[TransactionCreate]
+) -> ReconcileResult[Transaction, TransactionCreate]:
+    return reconcile(existing, parsed, key_fn=_transaction_key, diff_fields=TRANSACTION_DIFF_FIELDS)

--- a/backend/src/windfalls_csv.py
+++ b/backend/src/windfalls_csv.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import csv
+import io
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import date
+
+from pydantic import ValidationError
+
+from src.csv_match import ReconcileResult, reconcile
+from src.models.windfall import Windfall
+from src.schemas.windfall import WindfallCreate
+
+CSV_COLUMNS = ["name", "amount", "expected_date", "enabled"]
+
+# name/amount_cents/expected_date are the match key itself (see
+# _windfall_key) - enabled is the only field left over to diff, so a matched
+# windfall row only ever changes via being (re-)enabled/disabled, never a
+# genuine field edit. That's expected: Windfall has no other mutable fields.
+WINDFALL_DIFF_FIELDS = ["enabled"]
+
+
+@dataclass
+class RowError:
+    row: int  # 1-indexed, counting the header as row 1 (so row 2 is the first data row)
+    message: str
+
+
+def windfall_to_csv_row(windfall: Windfall) -> dict:
+    return {
+        "name": windfall.name,
+        "amount": f"{windfall.amount_cents / 100:.2f}",
+        "expected_date": windfall.expected_date.isoformat(),
+        "enabled": "true" if windfall.enabled else "false",
+    }
+
+
+def windfalls_to_csv(windfalls: list[Windfall]) -> str:
+    buffer = io.StringIO()
+    writer = csv.DictWriter(buffer, fieldnames=CSV_COLUMNS)
+    writer.writeheader()
+    for windfall in windfalls:
+        writer.writerow(windfall_to_csv_row(windfall))
+    return buffer.getvalue()
+
+
+def _parse_amount_cents(raw: str) -> int:
+    return round(float(raw) * 100)
+
+
+def _field(row: dict, key: str) -> str:
+    # csv.DictReader sets missing trailing fields to None (restval), not an
+    # absent key - row.get(key, "") only covers a truly absent key, so a
+    # short row would otherwise hit `.strip()` on None and raise
+    # AttributeError instead of a clean per-row ValueError.
+    return (row.get(key) or "").strip()
+
+
+def _parse_row(row: dict) -> WindfallCreate:
+    name = _field(row, "name")
+    if not name:
+        raise ValueError("name is required")
+
+    amount_raw = _field(row, "amount")
+    if not amount_raw:
+        raise ValueError("amount is required")
+    amount_cents = _parse_amount_cents(amount_raw)
+    if amount_cents <= 0:
+        raise ValueError("amount must be greater than zero")
+
+    expected_date_raw = _field(row, "expected_date")
+    if not expected_date_raw:
+        raise ValueError("expected_date is required")
+    expected_date = date.fromisoformat(expected_date_raw)
+
+    enabled_raw = _field(row, "enabled").lower()
+    enabled = enabled_raw not in ("false", "0")
+
+    return WindfallCreate(
+        name=name, amount_cents=amount_cents, expected_date=expected_date, enabled=enabled
+    )
+
+
+def parse_csv_rows(csv_text: str) -> tuple[list[WindfallCreate], list[RowError]]:
+    """All-or-nothing: every row is validated before any is returned as
+    importable. If `errors` is non-empty, `windfalls` should not be inserted."""
+    reader = csv.DictReader(io.StringIO(csv_text))
+    windfalls: list[WindfallCreate] = []
+    errors: list[RowError] = []
+
+    for row_number, row in enumerate(reader, start=2):  # row 1 is the header
+        try:
+            windfalls.append(_parse_row(row))
+        except (ValueError, TypeError, ValidationError) as exc:
+            errors.append(RowError(row=row_number, message=str(exc)))
+
+    return windfalls, errors
+
+
+def _windfall_key(row: Windfall | WindfallCreate) -> tuple:
+    return (row.name.strip().lower(), row.amount_cents, row.expected_date)
+
+
+def reconcile_windfalls(
+    existing: Sequence[Windfall], parsed: Sequence[WindfallCreate]
+) -> ReconcileResult[Windfall, WindfallCreate]:
+    return reconcile(existing, parsed, key_fn=_windfall_key, diff_fields=WINDFALL_DIFF_FIELDS)

--- a/backend/tests/test_bills_api.py
+++ b/backend/tests/test_bills_api.py
@@ -259,7 +259,14 @@ async def test_export_bills_scoped_to_account_owner(client: AsyncClient):
     assert res.status_code == 404
 
 
-async def test_import_bills_creates_all_rows(client: AsyncClient):
+async def _preview(client: AsyncClient, account_id: int, csv_text: str):
+    return await client.post(
+        f"/api/v1/accounts/{account_id}/bills/import/preview",
+        files={"file": ("bills.csv", csv_text, "text/csv")},
+    )
+
+
+async def test_preview_bill_import_buckets_new_rows(client: AsyncClient):
     account = await _create_account(client)
     csv_text = (
         "name,amount,recurrence_type,semimonthly_days,custom_interval_days,"
@@ -267,23 +274,52 @@ async def test_import_bills_creates_all_rows(client: AsyncClient):
         "Rent,1500.00,monthly,,,2026-01-01,,true,\n"
         "Paycheck buffer,50.00,semimonthly,\"10,25\",,2026-01-01,,true,imported\n"
     )
-    res = await client.post(
-        f"/api/v1/accounts/{account['id']}/bills/import",
-        files={"file": ("bills.csv", csv_text, "text/csv")},
-    )
-    assert res.status_code == 201
+    res = await _preview(client, account["id"], csv_text)
+    assert res.status_code == 200
     body = res.json()
-    assert len(body) == 2
-    assert {b["name"] for b in body} == {"Rent", "Paycheck buffer"}
-    semimonthly = next(b for b in body if b["name"] == "Paycheck buffer")
-    assert semimonthly["recurrence_config"] == {"days": [10, 25]}
-    assert semimonthly["notes"] == "imported"
+    assert len(body["new"]) == 2
+    assert {b["name"] for b in body["new"]} == {"Rent", "Paycheck buffer"}
+    assert body["updated"] == []
+    assert body["unchanged_count"] == 0
+    assert body["ambiguous"] == []
+    assert body["omitted"] == []
+
+    # Preview alone writes nothing.
+    res = await client.get(f"/api/v1/accounts/{account['id']}/bills")
+    assert res.json() == []
+
+
+async def test_commit_bill_import_creates_new_rows(client: AsyncClient):
+    account = await _create_account(client)
+    payload = {
+        "new": [
+            {
+                "name": "Rent",
+                "amount_cents": 150000,
+                "recurrence_type": "monthly",
+                "recurrence_config": {},
+                "start_date": "2026-01-01",
+                "end_date": None,
+                "enabled": True,
+                "notes": None,
+            }
+        ],
+        "updated": [],
+        "omitted_ids": [],
+    }
+    res = await client.post(f"/api/v1/accounts/{account['id']}/bills/import/commit", json=payload)
+    assert res.status_code == 200
+    body = res.json()
+    assert len(body["created"]) == 1
+    assert body["created"][0]["name"] == "Rent"
+    assert body["updated"] == []
+    assert body["disabled_count"] == 0
 
     res = await client.get(f"/api/v1/accounts/{account['id']}/bills")
-    assert len(res.json()) == 2
+    assert len(res.json()) == 1
 
 
-async def test_import_bills_is_all_or_nothing_on_a_bad_row(client: AsyncClient):
+async def test_preview_bill_import_is_all_or_nothing_on_a_bad_row(client: AsyncClient):
     account = await _create_account(client)
     csv_text = (
         "name,amount,recurrence_type,semimonthly_days,custom_interval_days,"
@@ -291,10 +327,7 @@ async def test_import_bills_is_all_or_nothing_on_a_bad_row(client: AsyncClient):
         "Rent,1500.00,monthly,,,2026-01-01,,true,\n"
         ",50.00,monthly,,,2026-01-01,,true,\n"
     )
-    res = await client.post(
-        f"/api/v1/accounts/{account['id']}/bills/import",
-        files={"file": ("bills.csv", csv_text, "text/csv")},
-    )
+    res = await _preview(client, account["id"], csv_text)
     assert res.status_code == 422
     errors = res.json()["detail"]["errors"]
     assert len(errors) == 1
@@ -304,7 +337,7 @@ async def test_import_bills_is_all_or_nothing_on_a_bad_row(client: AsyncClient):
     assert res.json() == []
 
 
-async def test_import_bills_scoped_to_account_owner(client: AsyncClient):
+async def test_preview_bill_import_scoped_to_account_owner(client: AsyncClient):
     account = await _create_account(client)
     csv_text = (
         "name,amount,recurrence_type,semimonthly_days,custom_interval_days,"
@@ -313,8 +346,136 @@ async def test_import_bills_scoped_to_account_owner(client: AsyncClient):
     )
 
     _login_as("auth0|someone-else")
-    res = await client.post(
-        f"/api/v1/accounts/{account['id']}/bills/import",
-        files={"file": ("bills.csv", csv_text, "text/csv")},
-    )
+    res = await _preview(client, account["id"], csv_text)
     assert res.status_code == 404
+
+
+async def test_commit_bill_import_scoped_to_account_owner(client: AsyncClient):
+    account = await _create_account(client)
+    payload = {"new": [], "updated": [], "omitted_ids": []}
+
+    _login_as("auth0|someone-else")
+    res = await client.post(f"/api/v1/accounts/{account['id']}/bills/import/commit", json=payload)
+    assert res.status_code == 404
+
+
+async def test_reimporting_unmodified_export_is_all_unchanged(client: AsyncClient):
+    account = await _create_account(client)
+    await client.post(f"/api/v1/accounts/{account['id']}/bills", json=_bill_payload(recurrence_config={}))
+
+    export_res = await client.get(f"/api/v1/accounts/{account['id']}/bills/export")
+    res = await _preview(client, account["id"], export_res.text)
+    body = res.json()
+    assert body["new"] == []
+    assert body["updated"] == []
+    assert body["unchanged_count"] == 1
+    assert body["ambiguous"] == []
+    assert body["omitted"] == []
+
+
+async def test_reimporting_edited_non_key_field_shows_as_updated(client: AsyncClient):
+    account = await _create_account(client)
+    await client.post(f"/api/v1/accounts/{account['id']}/bills", json=_bill_payload(recurrence_config={}))
+
+    csv_text = (
+        "name,amount,recurrence_type,semimonthly_days,custom_interval_days,"
+        "start_date,end_date,enabled,notes\n"
+        "Rent,1500.00,monthly,,,2026-01-01,,true,edited via csv\n"
+    )
+    res = await _preview(client, account["id"], csv_text)
+    body = res.json()
+    assert body["new"] == []
+    assert len(body["updated"]) == 1
+    assert body["updated"][0]["fields"]["notes"] == "edited via csv"
+    assert body["unchanged_count"] == 0
+    assert body["omitted"] == []
+
+
+async def test_commit_bill_import_update_preserves_history(client: AsyncClient):
+    account = await _create_account(client)
+    create_res = await client.post(
+        f"/api/v1/accounts/{account['id']}/bills", json=_bill_payload(recurrence_config={})
+    )
+    bill_id = create_res.json()["id"]
+
+    csv_text = (
+        "name,amount,recurrence_type,semimonthly_days,custom_interval_days,"
+        "start_date,end_date,enabled,notes\n"
+        "Rent,1500.00,monthly,,,2026-01-01,,true,edited via csv\n"
+    )
+    preview = (await _preview(client, account["id"], csv_text)).json()
+
+    commit_res = await client.post(
+        f"/api/v1/accounts/{account['id']}/bills/import/commit",
+        json={"new": [], "updated": preview["updated"], "omitted_ids": []},
+    )
+    assert commit_res.status_code == 200
+    commit_body = commit_res.json()
+    assert commit_body["updated"][0]["id"] == bill_id
+    assert commit_body["updated"][0]["notes"] == "edited via csv"
+
+    events_res = await client.get(f"/api/v1/accounts/{account['id']}/bills/{bill_id}/events")
+    event_types = [e["event_type"] for e in events_res.json()["events"]]
+    assert "created" in event_types
+    assert "notes_changed" in event_types
+
+
+async def test_bill_omitted_from_csv_is_disabled_not_deleted(client: AsyncClient):
+    account = await _create_account(client)
+    kept = await client.post(
+        f"/api/v1/accounts/{account['id']}/bills", json=_bill_payload(recurrence_config={})
+    )
+    omitted = await client.post(
+        f"/api/v1/accounts/{account['id']}/bills",
+        json=_bill_payload(name="Internet", amount_cents=8000, recurrence_config={}),
+    )
+    omitted_id = omitted.json()["id"]
+
+    # CSV only re-lists the "kept" bill - "Internet" is omitted.
+    csv_text = (
+        "name,amount,recurrence_type,semimonthly_days,custom_interval_days,"
+        "start_date,end_date,enabled,notes\n"
+        "Rent,1500.00,monthly,,,2026-01-01,,true,\n"
+    )
+    preview = (await _preview(client, account["id"], csv_text)).json()
+    assert len(preview["omitted"]) == 1
+    assert preview["omitted"][0]["id"] == omitted_id
+
+    commit_res = await client.post(
+        f"/api/v1/accounts/{account['id']}/bills/import/commit",
+        json={"new": [], "updated": [], "omitted_ids": [row["id"] for row in preview["omitted"]]},
+    )
+    assert commit_res.status_code == 200
+    assert commit_res.json()["disabled_count"] == 1
+
+    # Still exists, just disabled - not deleted.
+    list_res = await client.get(f"/api/v1/accounts/{account['id']}/bills")
+    names_by_enabled = {b["name"]: b["enabled"] for b in list_res.json()}
+    assert names_by_enabled == {"Rent": True, "Internet": False}
+
+    # History survives.
+    events_res = await client.get(f"/api/v1/accounts/{account['id']}/bills/{omitted_id}/events")
+    event_types = [e["event_type"] for e in events_res.json()["events"]]
+    assert "created" in event_types
+    assert "disabled" in event_types
+
+    assert kept.status_code == 201  # sanity: the "kept" bill was actually created
+
+
+async def test_preview_bill_import_flags_ambiguous_matches(client: AsyncClient):
+    account = await _create_account(client)
+    duplicate_payload = _bill_payload(recurrence_config={})
+    await client.post(f"/api/v1/accounts/{account['id']}/bills", json=duplicate_payload)
+    await client.post(f"/api/v1/accounts/{account['id']}/bills", json=duplicate_payload)
+
+    csv_text = (
+        "name,amount,recurrence_type,semimonthly_days,custom_interval_days,"
+        "start_date,end_date,enabled,notes\n"
+        "Rent,1500.00,monthly,,,2026-01-01,,true,\n"
+    )
+    res = await _preview(client, account["id"], csv_text)
+    body = res.json()
+    assert body["new"] == []
+    assert body["updated"] == []
+    assert len(body["ambiguous"]) == 1
+    assert "matches 2 existing bills" in body["ambiguous"][0]["message"]

--- a/backend/tests/test_csv_match.py
+++ b/backend/tests/test_csv_match.py
@@ -1,0 +1,83 @@
+from dataclasses import dataclass
+
+from src.csv_match import reconcile
+
+
+@dataclass
+class _Existing:
+    id: int
+    key: str
+    value: int
+
+
+@dataclass
+class _Parsed:
+    key: str
+    value: int
+
+
+def _key(row: _Existing | _Parsed) -> str:
+    return row.key
+
+
+def test_row_with_no_matching_key_is_new():
+    result = reconcile([], [_Parsed(key="a", value=1)], key_fn=_key, diff_fields=["value"])
+    assert result.new == [_Parsed(key="a", value=1)]
+    assert result.updated == []
+    assert result.unchanged == []
+    assert result.ambiguous == []
+    assert result.omitted == []
+
+
+def test_matching_row_with_identical_diff_fields_is_unchanged():
+    existing = _Existing(id=1, key="a", value=1)
+    result = reconcile([existing], [_Parsed(key="a", value=1)], key_fn=_key, diff_fields=["value"])
+    assert result.new == []
+    assert result.updated == []
+    assert result.unchanged == [existing]
+    assert result.omitted == []
+
+
+def test_matching_row_with_different_diff_field_is_updated():
+    existing = _Existing(id=1, key="a", value=1)
+    parsed = _Parsed(key="a", value=2)
+    result = reconcile([existing], [parsed], key_fn=_key, diff_fields=["value"])
+    assert result.new == []
+    assert result.unchanged == []
+    assert len(result.updated) == 1
+    assert result.updated[0].existing is existing
+    assert result.updated[0].parsed is parsed
+
+
+def test_key_matching_multiple_existing_rows_is_ambiguous():
+    dup_a = _Existing(id=1, key="a", value=1)
+    dup_b = _Existing(id=2, key="a", value=1)
+    parsed = _Parsed(key="a", value=1)
+    result = reconcile([dup_a, dup_b], [parsed], key_fn=_key, diff_fields=["value"])
+    assert result.new == []
+    assert result.updated == []
+    assert result.unchanged == []
+    assert len(result.ambiguous) == 1
+    assert result.ambiguous[0].parsed is parsed
+    assert result.ambiguous[0].matches == [dup_a, dup_b]
+    # An ambiguous existing row isn't also reported as omitted - its key did
+    # appear in the CSV, just too many times to resolve automatically.
+    assert result.omitted == []
+
+
+def test_existing_row_absent_from_any_parsed_row_is_omitted():
+    existing = _Existing(id=1, key="a", value=1)
+    result = reconcile([existing], [], key_fn=_key, diff_fields=["value"])
+    assert result.new == []
+    assert result.updated == []
+    assert result.unchanged == []
+    assert result.ambiguous == []
+    assert result.omitted == [existing]
+
+
+def test_omitted_and_matched_rows_coexist_correctly():
+    kept = _Existing(id=1, key="a", value=1)
+    dropped = _Existing(id=2, key="b", value=1)
+    result = reconcile([kept, dropped], [_Parsed(key="a", value=1)], key_fn=_key, diff_fields=["value"])
+    assert result.unchanged == [kept]
+    assert result.omitted == [dropped]

--- a/backend/tests/test_transactions_api.py
+++ b/backend/tests/test_transactions_api.py
@@ -219,3 +219,155 @@ async def test_transactions_scoped_to_account_owner(client: AsyncClient):
         f"/api/v1/accounts/{account['id']}/transactions", json=_transaction_payload()
     )
     assert res.status_code == 404
+
+
+async def _create_bill(client: AsyncClient, account_id: int, **overrides) -> dict:
+    payload = {
+        "name": "Rent",
+        "amount_cents": 150000,
+        "recurrence_type": "monthly",
+        "start_date": "2024-01-01",
+    }
+    payload.update(overrides)
+    res = await client.post(f"/api/v1/accounts/{account_id}/bills", json=payload)
+    return res.json()
+
+
+async def _preview(client: AsyncClient, account_id: int, csv_text: str):
+    return await client.post(
+        f"/api/v1/accounts/{account_id}/transactions/import/preview",
+        files={"file": ("transactions.csv", csv_text, "text/csv")},
+    )
+
+
+async def test_export_transactions_includes_linked_bill_name(client: AsyncClient):
+    account = await _create_account(client)
+    bill = await _create_bill(client, account["id"])
+    await client.post(
+        f"/api/v1/accounts/{account['id']}/transactions",
+        json=_transaction_payload(bill_id=bill["id"]),
+    )
+
+    res = await client.get(f"/api/v1/accounts/{account['id']}/transactions/export")
+    assert res.status_code == 200
+    assert "bill_name" in res.text
+    assert "Rent" in res.text
+
+
+async def test_preview_transaction_import_resolves_bill_name_to_bill_id(client: AsyncClient):
+    account = await _create_account(client)
+    bill = await _create_bill(client, account["id"])
+    csv_text = "date,amount,description,bill_name\n2024-01-15,-25.00,Coffee,Rent\n"
+
+    res = await _preview(client, account["id"], csv_text)
+    assert res.status_code == 200
+    body = res.json()
+    assert len(body["new"]) == 1
+    assert body["new"][0]["bill_id"] == bill["id"]
+    assert body["warnings"] == []
+
+
+async def test_preview_transaction_import_warns_on_unresolved_bill_name(client: AsyncClient):
+    account = await _create_account(client)
+    csv_text = "date,amount,description,bill_name\n2024-01-15,-25.00,Coffee,Nonexistent\n"
+
+    res = await _preview(client, account["id"], csv_text)
+    body = res.json()
+    assert body["new"][0]["bill_id"] is None
+    assert len(body["warnings"]) == 1
+    assert "Nonexistent" in body["warnings"][0]["message"]
+
+
+async def test_preview_transaction_import_warns_on_ambiguous_bill_name(client: AsyncClient):
+    account = await _create_account(client)
+    await _create_bill(client, account["id"])
+    await _create_bill(client, account["id"])
+    csv_text = "date,amount,description,bill_name\n2024-01-15,-25.00,Coffee,Rent\n"
+
+    res = await _preview(client, account["id"], csv_text)
+    body = res.json()
+    assert body["new"][0]["bill_id"] is None
+    assert len(body["warnings"]) == 1
+    assert "Rent" in body["warnings"][0]["message"]
+
+
+async def test_commit_transaction_import_creates_new_rows(client: AsyncClient):
+    account = await _create_account(client)
+    payload = {
+        "new": [{"amount_cents": -2500, "date": "2024-01-15", "description": "Coffee", "bill_id": None}],
+        "updated": [],
+        "omitted_ids": [],
+    }
+    res = await client.post(
+        f"/api/v1/accounts/{account['id']}/transactions/import/commit", json=payload
+    )
+    assert res.status_code == 200
+    assert len(res.json()["created"]) == 1
+
+    res = await client.get(f"/api/v1/accounts/{account['id']}/transactions")
+    assert len(res.json()) == 1
+
+
+async def test_reimporting_unmodified_export_is_all_unchanged(client: AsyncClient):
+    account = await _create_account(client)
+    await client.post(f"/api/v1/accounts/{account['id']}/transactions", json=_transaction_payload())
+
+    export_res = await client.get(f"/api/v1/accounts/{account['id']}/transactions/export")
+    res = await _preview(client, account["id"], export_res.text)
+    body = res.json()
+    assert body["new"] == []
+    assert body["updated"] == []
+    assert body["unchanged_count"] == 1
+    assert body["omitted"] == []
+
+
+async def test_reimporting_with_new_bill_link_shows_as_updated(client: AsyncClient):
+    account = await _create_account(client)
+    bill = await _create_bill(client, account["id"])
+    await client.post(f"/api/v1/accounts/{account['id']}/transactions", json=_transaction_payload())
+
+    csv_text = f"date,amount,description,bill_name\n2024-01-15,-25.00,Coffee,{bill['name']}\n"
+    res = await _preview(client, account["id"], csv_text)
+    body = res.json()
+    assert body["new"] == []
+    assert len(body["updated"]) == 1
+    assert body["updated"][0]["fields"]["bill_id"] == bill["id"]
+
+
+async def test_transaction_omitted_from_csv_is_hard_deleted(client: AsyncClient):
+    account = await _create_account(client)
+    kept = await client.post(
+        f"/api/v1/accounts/{account['id']}/transactions", json=_transaction_payload()
+    )
+    dropped = await client.post(
+        f"/api/v1/accounts/{account['id']}/transactions",
+        json=_transaction_payload(description="Groceries", amount_cents=-5000),
+    )
+    dropped_id = dropped.json()["id"]
+
+    csv_text = "date,amount,description,bill_name\n2024-01-15,-25.00,Coffee,\n"
+    preview = (await _preview(client, account["id"], csv_text)).json()
+    assert len(preview["omitted"]) == 1
+    assert preview["omitted"][0]["id"] == dropped_id
+
+    commit_res = await client.post(
+        f"/api/v1/accounts/{account['id']}/transactions/import/commit",
+        json={"new": [], "updated": [], "omitted_ids": [row["id"] for row in preview["omitted"]]},
+    )
+    assert commit_res.status_code == 200
+    assert commit_res.json()["deleted_count"] == 1
+
+    list_res = await client.get(f"/api/v1/accounts/{account['id']}/transactions")
+    descriptions = {t["description"] for t in list_res.json()}
+    assert descriptions == {"Coffee"}
+
+    assert kept.status_code == 201  # sanity: the "kept" transaction was actually created
+
+
+async def test_preview_transaction_import_scoped_to_account_owner(client: AsyncClient):
+    account = await _create_account(client)
+    csv_text = "date,amount,description,bill_name\n2024-01-15,-25.00,Coffee,\n"
+
+    _login_as("auth0|someone-else")
+    res = await _preview(client, account["id"], csv_text)
+    assert res.status_code == 404

--- a/backend/tests/test_windfalls_api.py
+++ b/backend/tests/test_windfalls_api.py
@@ -161,3 +161,142 @@ async def test_windfalls_scoped_to_account_owner(client: AsyncClient):
         f"/api/v1/accounts/{account['id']}/windfalls", json=_windfall_payload()
     )
     assert res.status_code == 404
+
+
+async def _preview(client: AsyncClient, account_id: int, csv_text: str):
+    return await client.post(
+        f"/api/v1/accounts/{account_id}/windfalls/import/preview",
+        files={"file": ("windfalls.csv", csv_text, "text/csv")},
+    )
+
+
+async def test_preview_windfall_import_buckets_new_rows(client: AsyncClient):
+    account = await _create_account(client)
+    csv_text = "name,amount,expected_date,enabled\nTax refund,500.00,2024-04-15,true\n"
+
+    res = await _preview(client, account["id"], csv_text)
+    assert res.status_code == 200
+    body = res.json()
+    assert len(body["new"]) == 1
+    assert body["new"][0]["name"] == "Tax refund"
+    assert body["updated"] == []
+    assert body["unchanged_count"] == 0
+    assert body["omitted"] == []
+
+
+async def test_commit_windfall_import_creates_new_rows(client: AsyncClient):
+    account = await _create_account(client)
+    payload = {
+        "new": [
+            {
+                "name": "Tax refund",
+                "amount_cents": 50000,
+                "expected_date": "2024-04-15",
+                "enabled": True,
+            }
+        ],
+        "updated": [],
+        "omitted_ids": [],
+    }
+    res = await client.post(f"/api/v1/accounts/{account['id']}/windfalls/import/commit", json=payload)
+    assert res.status_code == 200
+    assert len(res.json()["created"]) == 1
+
+    res = await client.get(f"/api/v1/accounts/{account['id']}/windfalls")
+    assert len(res.json()) == 1
+
+
+async def test_reimporting_unmodified_export_is_all_unchanged(client: AsyncClient):
+    account = await _create_account(client)
+    await client.post(f"/api/v1/accounts/{account['id']}/windfalls", json=_windfall_payload())
+
+    export_res = await client.get(f"/api/v1/accounts/{account['id']}/windfalls/export")
+    res = await _preview(client, account["id"], export_res.text)
+    body = res.json()
+    assert body["new"] == []
+    assert body["updated"] == []
+    assert body["unchanged_count"] == 1
+    assert body["omitted"] == []
+
+
+async def test_windfall_omitted_from_csv_is_disabled_not_deleted(client: AsyncClient):
+    account = await _create_account(client)
+    kept = await client.post(
+        f"/api/v1/accounts/{account['id']}/windfalls", json=_windfall_payload()
+    )
+    dropped = await client.post(
+        f"/api/v1/accounts/{account['id']}/windfalls",
+        json=_windfall_payload(name="Bonus", amount_cents=100000, expected_date="2024-12-01"),
+    )
+    dropped_id = dropped.json()["id"]
+
+    csv_text = "name,amount,expected_date,enabled\nTax refund,500.00,2024-04-15,true\n"
+    preview = (await _preview(client, account["id"], csv_text)).json()
+    assert len(preview["omitted"]) == 1
+    assert preview["omitted"][0]["id"] == dropped_id
+
+    commit_res = await client.post(
+        f"/api/v1/accounts/{account['id']}/windfalls/import/commit",
+        json={"new": [], "updated": [], "omitted_ids": [row["id"] for row in preview["omitted"]]},
+    )
+    assert commit_res.status_code == 200
+    assert commit_res.json()["disabled_count"] == 1
+
+    # Still exists, just disabled - not deleted.
+    list_res = await client.get(f"/api/v1/accounts/{account['id']}/windfalls")
+    enabled_by_name = {w["name"]: w["enabled"] for w in list_res.json()}
+    assert enabled_by_name == {"Tax refund": True, "Bonus": False}
+
+    assert kept.status_code == 201  # sanity: the "kept" windfall was actually created
+
+
+async def test_disabled_windfall_excluded_from_forecast(client: AsyncClient):
+    account = await _create_account(client)
+    windfall = (
+        await client.post(
+            f"/api/v1/accounts/{account['id']}/windfalls", json=_windfall_payload()
+        )
+    ).json()
+    await client.patch(
+        f"/api/v1/accounts/{account['id']}/windfalls/{windfall['id']}", json={"enabled": False}
+    )
+
+    res = await client.post(
+        f"/api/v1/accounts/{account['id']}/forecast",
+        json={
+            "starting_balance_cents": 100000,
+            "income_per_cycle_cents": 0,
+            "cycle_type": "monthly",
+            "start_date": "2024-01-01",
+            "end_date": "2024-12-31",
+        },
+    )
+    assert res.status_code == 200
+    all_windfall_ids = {
+        w["windfall_id"] for cycle in res.json()["cycles"] for w in cycle.get("windfalls", [])
+    }
+    assert windfall["id"] not in all_windfall_ids
+
+
+async def test_preview_windfall_import_flags_ambiguous_matches(client: AsyncClient):
+    account = await _create_account(client)
+    duplicate_payload = _windfall_payload()
+    await client.post(f"/api/v1/accounts/{account['id']}/windfalls", json=duplicate_payload)
+    await client.post(f"/api/v1/accounts/{account['id']}/windfalls", json=duplicate_payload)
+
+    csv_text = "name,amount,expected_date,enabled\nTax refund,500.00,2024-04-15,true\n"
+    res = await _preview(client, account["id"], csv_text)
+    body = res.json()
+    assert body["new"] == []
+    assert body["updated"] == []
+    assert len(body["ambiguous"]) == 1
+    assert "matches 2 existing windfalls" in body["ambiguous"][0]["message"]
+
+
+async def test_preview_windfall_import_scoped_to_account_owner(client: AsyncClient):
+    account = await _create_account(client)
+    csv_text = "name,amount,expected_date,enabled\nTax refund,500.00,2024-04-15,true\n"
+
+    _login_as("auth0|someone-else")
+    res = await _preview(client, account["id"], csv_text)
+    assert res.status_code == 404

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -270,14 +270,18 @@ per-PR preview branch) make manual Neon console clicks a recurring chore.
       (previously always omitted). Also rebuilt `Select.svelte` as a custom Tailwind
       popover listbox (mirroring `DatePicker.svelte`'s pattern) instead of a native
       `<select>`, since this item needed more per-type fields on top of it.
-- [x] 1.8 Bills CSV import/export per bank account. Backend: `GET/POST
-      .../bills/{export,import}` (`backend/src/bills_csv.py`, `backend/src/api/bills.py`) -
+- [x] 1.8 CSV import/export for Bills, Transactions, and Windfalls, with reconciliation on
+      reimport instead of insert-only duplication - see the 2026-07-15 changelog entry
+      below for the full design (fuzzy field-match, preview-then-confirm, and per-type
+      omitted-row semantics that avoid cascading away `bill_events`/`cycle_overrides`
+      history). Backend: `GET .../{bills,transactions,windfalls}/export`,
+      `POST .../import/{preview,commit}` (`backend/src/{bills,transactions,windfalls}_csv.py`,
+      `backend/src/csv_match.py`, `backend/src/api/{bills,transactions,windfalls}.py`) -
       dollars not cents, `semimonthly_days`/`custom_interval_days` as their own columns
-      instead of raw JSON, all-or-nothing import validation (a 422 with a per-row error
-      list if any row fails, nothing inserted). Frontend: Import/Export buttons on the
-      bills page (`frontend/src/lib/api/bills.ts`'s `exportBillsCsv`/`importBillsCsv`, via
-      `apiFetch` directly rather than `apiJson` since a CSV blob/multipart upload isn't
-      JSON).
+      instead of raw JSON. Frontend: a new per-account Settings page
+      (`frontend/src/routes/(app)/accounts/[id]/settings/+page.svelte`, linked from
+      `AccountNav`) is now the one place for all three types' Import/Export, replacing the
+      original Bills-page-only buttons.
 - [x] 1.9 Bill notes support. `Bill.notes` (nullable, migration `12aa348bb14f`), threaded
       through `BillCreate`/`Update`/`Read` and the create form + edit modal (no dedicated
       bills-table column, to avoid clutter - the edit modal is the "detail affordance").
@@ -1063,3 +1067,61 @@ session (or a fresh Claude Code instance) orient in under a minute.
   next cycle, prefilling starting balance from the current cycle's ending balance) -
   not started, captured per Ken's request. Next: Phase 5's remaining items, Phase
   7/8/9/10 whenever it's time, or any newly-discovered polish item.
+- 2026-07-15: Expanded 1.8 from Bills-only CSV import/export into all three types
+  (Bills/Transactions/Windfalls), with reconciliation on reimport per Ken's request -
+  re-importing shouldn't duplicate rows that are already there, and (the harder
+  constraint) reconciliation must never destroy history: `bill_events` and
+  `cycle_overrides`/`bill_history` hang off a bill's or windfall's `id` via
+  `ondelete="CASCADE"`, so a naive delete-and-reinsert on every import would silently
+  wipe them even for a row that's logically unchanged. Design, in order of what it took
+  to get right:
+  - **Matching**: fuzzy field-match per type (no id column round-tripped through the
+    CSV, so it works for hand-edited CSVs and re-exports alike) - Bills key on
+    `(name, amount_cents, recurrence_type, start_date)`, Transactions on
+    `(date, amount_cents, description)`, Windfalls on `(name, amount_cents,
+    expected_date)`. New shared `backend/src/csv_match.py` (generic `reconcile()`,
+    PEP 695 type params) buckets every parsed row into new/updated/unchanged/ambiguous
+    (2+ existing rows share a key - excluded from commit, reported for manual
+    resolution) plus omitted (an existing row's key never appeared in the file).
+  - **On match**: update the existing row's other fields in place - for Bills this
+    reuses `update_events` (the same before/after diff helper `PATCH /bills/{id}`
+    already uses), so a CSV-driven edit produces the identical `bill_events.UPDATED`
+    entry a UI edit would.
+  - **Sync/omitted semantics, chosen per-type specifically to avoid the cascade-delete
+    problem**: Bills and Windfalls omitted from a reimport are soft-deleted
+    (`enabled = False`, reusing the same mechanism `_auto_disable_expired` already used
+    for expired bills - a new `disabled_event()` helper in `bill_events.py` covers both
+    call sites) rather than hard-deleted, so their history survives and they can
+    reappear in a later import. This required adding `Windfall.enabled` (migration
+    `b88c09336fb3`), which didn't exist before - threaded through
+    `WindfallCreate`/`Update`/`Read`, the windfalls list page (new enabled/disabled
+    `Badge` + toggle, mirroring Bills), and excluded from `/forecast` and `/dashboard`'s
+    windfall queries the same way `Bill.enabled` already was. Transactions, by contrast,
+    have no downstream table referencing `transactions.id` and no soft-delete flag, so
+    an omitted transaction is hard-deleted - reconciling against a full transaction
+    export can genuinely prune stale rows, at the cost of that being irreversible (the
+    Settings page requires an explicit "I understand this cannot be undone" acknowledgement
+    before a commit with any omitted transactions is allowed through).
+  - **Preview before commit, not apply-immediately**: `POST .../import/preview` parses
+    and matches without writing anything, returning the five buckets; the frontend
+    shows counts and confirms before `POST .../import/commit` - which receives back
+    the *same* new/updated/omitted-ids shape the preview returned (not the original
+    file), keeping the Lambda side fully stateless (no server-held preview session).
+  - **Transaction↔Bill link**: represented in the CSV by the linked bill's *name*, not
+    id (`backend/src/transactions_csv.py`) - 0 or 2+ bills matching that name import
+    the transaction unlinked with a per-row warning rather than failing the row.
+  Frontend: new account-level Settings page
+  (`frontend/src/routes/(app)/accounts/[id]/settings/+page.svelte`, new `AccountNav` tab)
+  is the one place for all three types' Import/Export, replacing the original
+  Bills-page-only buttons; new shared `ImportPreviewModal.svelte` (presentational only -
+  each page formats its own new/updated/omitted rows into plain-string summaries before
+  passing them in) renders the preview and gates the Transactions delete-acknowledgement
+  checkbox. Also fixed an unrelated reported bug found along the way: the Bills page's
+  Amount input was missing `step="0.01"` (present on Transactions'/Windfalls' equivalents),
+  so browsers rounded to whole dollars - couldn't enter e.g. 79.99. Backend: 192 tests pass
+  (44 new), ruff clean. Frontend: lint/`svelte-check`/tests all clean (Node 24 required -
+  the sandbox's default Node 20.9 predates `node:util`'s `styleText` export that
+  `@sveltejs/vite-plugin-svelte` now needs; `nvm use v24.11.0` first). Not yet verified
+  in-browser via Playwright - next session should do that pass before considering this
+  fully done. Next: Phase 5's remaining items, Phase 7/8/9/10 whenever it's time, or any
+  newly-discovered polish item.

--- a/frontend/src/lib/api/bills.ts
+++ b/frontend/src/lib/api/bills.ts
@@ -4,6 +4,9 @@ import type {
 	BillEventCycleCountsResponse,
 	BillEventListResponse,
 	BillHistoryResponse,
+	BillImportCommitRequest,
+	BillImportCommitResponse,
+	BillImportPreview,
 	BillInput
 } from '$lib/api/types';
 
@@ -71,18 +74,18 @@ export async function exportBillsCsv(accountId: number): Promise<Blob> {
 	return res.blob();
 }
 
-export interface BillImportRowError {
+export interface ImportRowError {
 	row: number;
 	message: string;
 }
 
-export async function importBillsCsv(accountId: number, file: File): Promise<Bill[]> {
+export async function previewBillImportCsv(accountId: number, file: File): Promise<BillImportPreview> {
 	const formData = new FormData();
 	formData.append('file', file);
 	// apiFetch, not apiJson - a FormData body must NOT have a Content-Type set
 	// manually (the browser generates the multipart boundary itself); apiJson
 	// would force Content-Type: application/json since none is passed here.
-	const res = await apiFetch(`/api/v1/accounts/${accountId}/bills/import`, {
+	const res = await apiFetch(`/api/v1/accounts/${accountId}/bills/import/preview`, {
 		method: 'POST',
 		body: formData
 	});
@@ -95,4 +98,14 @@ export async function importBillsCsv(accountId: number, file: File): Promise<Bil
 		throw new ApiError(res.status, body);
 	}
 	return res.json();
+}
+
+export function commitBillImportCsv(
+	accountId: number,
+	payload: BillImportCommitRequest
+): Promise<BillImportCommitResponse> {
+	return apiJson(`/api/v1/accounts/${accountId}/bills/import/commit`, {
+		method: 'POST',
+		body: JSON.stringify(payload)
+	});
 }

--- a/frontend/src/lib/api/transactions.ts
+++ b/frontend/src/lib/api/transactions.ts
@@ -1,5 +1,11 @@
-import { apiJson } from '$lib/api';
-import type { Transaction, TransactionInput } from '$lib/api/types';
+import { apiFetch, apiJson, ApiError } from '$lib/api';
+import type {
+	Transaction,
+	TransactionImportCommitRequest,
+	TransactionImportCommitResponse,
+	TransactionImportPreview,
+	TransactionInput
+} from '$lib/api/types';
 
 export function listTransactions(accountId: number): Promise<Transaction[]> {
 	return apiJson(`/api/v1/accounts/${accountId}/transactions`);
@@ -29,5 +35,45 @@ export function updateTransaction(
 export function deleteTransaction(accountId: number, transactionId: number): Promise<void> {
 	return apiJson(`/api/v1/accounts/${accountId}/transactions/${transactionId}`, {
 		method: 'DELETE'
+	});
+}
+
+export async function exportTransactionsCsv(accountId: number): Promise<Blob> {
+	const res = await apiFetch(`/api/v1/accounts/${accountId}/transactions/export`);
+	if (!res.ok) throw new ApiError(res.status, await res.text());
+	return res.blob();
+}
+
+export async function previewTransactionImportCsv(
+	accountId: number,
+	file: File
+): Promise<TransactionImportPreview> {
+	const formData = new FormData();
+	formData.append('file', file);
+	// apiFetch, not apiJson - a FormData body must NOT have a Content-Type set
+	// manually (the browser generates the multipart boundary itself); apiJson
+	// would force Content-Type: application/json since none is passed here.
+	const res = await apiFetch(`/api/v1/accounts/${accountId}/transactions/import/preview`, {
+		method: 'POST',
+		body: formData
+	});
+	if (!res.ok) {
+		// Mirrors apiJson's error-body handling: an error response isn't
+		// guaranteed to be JSON (e.g. a proxy's 502/504 page), so a raw
+		// res.json() here could throw a parse error instead of a clean
+		// ApiError.
+		const body = await res.json().catch(() => null);
+		throw new ApiError(res.status, body);
+	}
+	return res.json();
+}
+
+export function commitTransactionImportCsv(
+	accountId: number,
+	payload: TransactionImportCommitRequest
+): Promise<TransactionImportCommitResponse> {
+	return apiJson(`/api/v1/accounts/${accountId}/transactions/import/commit`, {
+		method: 'POST',
+		body: JSON.stringify(payload)
 	});
 }

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -28,6 +28,21 @@ export interface BankAccountInput {
 	institution?: string | null;
 }
 
+// Shared shape across Bills/Transactions/Windfalls CSV import preview -
+// see docs/ROADMAP.md's CSV reconciliation entry for the full design.
+
+export interface ImportRowIssue {
+	row: number;
+	message: string;
+}
+
+export interface ImportAmbiguous {
+	// No row number - describes a match collision found during
+	// reconciliation (a CSV row's key matched more than one existing row),
+	// not a single malformed CSV row.
+	message: string;
+}
+
 export interface Bill {
 	id: number;
 	account_id: number;
@@ -54,6 +69,34 @@ export interface BillInput {
 	notes?: string | null;
 }
 
+export interface BillImportUpdate {
+	id: number;
+	fields: BillInput;
+}
+
+export interface BillImportPreview {
+	new: BillInput[];
+	updated: BillImportUpdate[];
+	unchanged_count: number;
+	ambiguous: ImportAmbiguous[];
+	// Currently-enabled bills that will be disabled (not deleted) if this
+	// preview is committed.
+	omitted: Bill[];
+	errors: ImportRowIssue[];
+}
+
+export interface BillImportCommitRequest {
+	new: BillInput[];
+	updated: BillImportUpdate[];
+	omitted_ids: number[];
+}
+
+export interface BillImportCommitResponse {
+	created: Bill[];
+	updated: Bill[];
+	disabled_count: number;
+}
+
 export interface Transaction {
 	id: number;
 	account_id: number;
@@ -72,6 +115,38 @@ export interface TransactionInput {
 	bill_id?: number | null;
 }
 
+export interface TransactionImportUpdate {
+	id: number;
+	fields: TransactionInput;
+}
+
+export interface TransactionImportPreview {
+	new: TransactionInput[];
+	updated: TransactionImportUpdate[];
+	unchanged_count: number;
+	ambiguous: ImportAmbiguous[];
+	// Existing transactions that will be *permanently deleted* if this
+	// preview is committed - unlike Bills/Windfalls there's no soft-delete
+	// flag for Transaction.
+	omitted: Transaction[];
+	// bill_name didn't resolve to exactly one bill on this account - the row
+	// still imports, just unlinked (bill_id null).
+	warnings: ImportRowIssue[];
+	errors: ImportRowIssue[];
+}
+
+export interface TransactionImportCommitRequest {
+	new: TransactionInput[];
+	updated: TransactionImportUpdate[];
+	omitted_ids: number[];
+}
+
+export interface TransactionImportCommitResponse {
+	created: Transaction[];
+	updated: Transaction[];
+	deleted_count: number;
+}
+
 export interface Windfall {
 	id: number;
 	account_id: number;
@@ -79,6 +154,7 @@ export interface Windfall {
 	// Always positive - a windfall is income by definition.
 	amount_cents: number;
 	expected_date: string;
+	enabled: boolean;
 	created_at: string;
 }
 
@@ -86,6 +162,35 @@ export interface WindfallInput {
 	name: string;
 	amount_cents: number;
 	expected_date: string;
+	enabled?: boolean;
+}
+
+export interface WindfallImportUpdate {
+	id: number;
+	fields: WindfallInput;
+}
+
+export interface WindfallImportPreview {
+	new: WindfallInput[];
+	updated: WindfallImportUpdate[];
+	unchanged_count: number;
+	ambiguous: ImportAmbiguous[];
+	// Currently-enabled windfalls that will be disabled (not deleted) if
+	// this preview is committed.
+	omitted: Windfall[];
+	errors: ImportRowIssue[];
+}
+
+export interface WindfallImportCommitRequest {
+	new: WindfallInput[];
+	updated: WindfallImportUpdate[];
+	omitted_ids: number[];
+}
+
+export interface WindfallImportCommitResponse {
+	created: Windfall[];
+	updated: Windfall[];
+	disabled_count: number;
 }
 
 export interface ForecastRequest {

--- a/frontend/src/lib/api/windfalls.ts
+++ b/frontend/src/lib/api/windfalls.ts
@@ -1,5 +1,11 @@
-import { apiJson } from '$lib/api';
-import type { Windfall, WindfallInput } from '$lib/api/types';
+import { apiFetch, apiJson, ApiError } from '$lib/api';
+import type {
+	Windfall,
+	WindfallImportCommitRequest,
+	WindfallImportCommitResponse,
+	WindfallImportPreview,
+	WindfallInput
+} from '$lib/api/types';
 
 export function listWindfalls(accountId: number): Promise<Windfall[]> {
 	return apiJson(`/api/v1/accounts/${accountId}/windfalls`);
@@ -26,5 +32,45 @@ export function updateWindfall(
 export function deleteWindfall(accountId: number, windfallId: number): Promise<void> {
 	return apiJson(`/api/v1/accounts/${accountId}/windfalls/${windfallId}`, {
 		method: 'DELETE'
+	});
+}
+
+export async function exportWindfallsCsv(accountId: number): Promise<Blob> {
+	const res = await apiFetch(`/api/v1/accounts/${accountId}/windfalls/export`);
+	if (!res.ok) throw new ApiError(res.status, await res.text());
+	return res.blob();
+}
+
+export async function previewWindfallImportCsv(
+	accountId: number,
+	file: File
+): Promise<WindfallImportPreview> {
+	const formData = new FormData();
+	formData.append('file', file);
+	// apiFetch, not apiJson - a FormData body must NOT have a Content-Type set
+	// manually (the browser generates the multipart boundary itself); apiJson
+	// would force Content-Type: application/json since none is passed here.
+	const res = await apiFetch(`/api/v1/accounts/${accountId}/windfalls/import/preview`, {
+		method: 'POST',
+		body: formData
+	});
+	if (!res.ok) {
+		// Mirrors apiJson's error-body handling: an error response isn't
+		// guaranteed to be JSON (e.g. a proxy's 502/504 page), so a raw
+		// res.json() here could throw a parse error instead of a clean
+		// ApiError.
+		const body = await res.json().catch(() => null);
+		throw new ApiError(res.status, body);
+	}
+	return res.json();
+}
+
+export function commitWindfallImportCsv(
+	accountId: number,
+	payload: WindfallImportCommitRequest
+): Promise<WindfallImportCommitResponse> {
+	return apiJson(`/api/v1/accounts/${accountId}/windfalls/import/commit`, {
+		method: 'POST',
+		body: JSON.stringify(payload)
 	});
 }

--- a/frontend/src/lib/components/AccountNav.svelte
+++ b/frontend/src/lib/components/AccountNav.svelte
@@ -4,14 +4,15 @@
 		current
 	}: {
 		accountId: number;
-		current: 'bills' | 'transactions' | 'windfalls' | 'forecast';
+		current: 'bills' | 'transactions' | 'windfalls' | 'forecast' | 'settings';
 	} = $props();
 
 	const links = $derived<{ key: typeof current; label: string; href: string }[]>([
 		{ key: 'bills', label: 'Bills', href: `/accounts/${accountId}` },
 		{ key: 'transactions', label: 'Transactions', href: `/accounts/${accountId}/transactions` },
 		{ key: 'windfalls', label: 'Windfalls', href: `/accounts/${accountId}/windfalls` },
-		{ key: 'forecast', label: 'Forecast', href: `/accounts/${accountId}/forecast` }
+		{ key: 'forecast', label: 'Forecast', href: `/accounts/${accountId}/forecast` },
+		{ key: 'settings', label: 'Settings', href: `/accounts/${accountId}/settings` }
 	]);
 </script>
 

--- a/frontend/src/lib/components/ImportPreviewModal.svelte
+++ b/frontend/src/lib/components/ImportPreviewModal.svelte
@@ -1,0 +1,139 @@
+<script lang="ts">
+	import Button from './Button.svelte';
+	import Modal from './Modal.svelte';
+
+	// Presentational only - Bills/Transactions/Windfalls each format their own
+	// rows into these plain-string summaries before passing them in, so this
+	// component doesn't need to know anything about the three entity shapes.
+	let {
+		open = $bindable(false),
+		title,
+		newSummaries,
+		updatedSummaries,
+		unchangedCount,
+		ambiguousMessages,
+		omittedSummaries,
+		// 'disable' (Bills/Windfalls - reversible, soft-delete) vs 'delete'
+		// (Transactions - permanent) - controls the omitted section's styling
+		// and whether an extra acknowledgement is required before confirming.
+		omittedSeverity,
+		confirming = false,
+		onconfirm,
+		oncancel
+	}: {
+		open: boolean;
+		title: string;
+		newSummaries: string[];
+		updatedSummaries: string[];
+		unchangedCount: number;
+		ambiguousMessages: string[];
+		omittedSummaries: string[];
+		omittedSeverity: 'disable' | 'delete';
+		confirming?: boolean;
+		onconfirm: () => void;
+		oncancel?: () => void;
+	} = $props();
+
+	let acknowledgedDeletion = $state(false);
+
+	$effect(() => {
+		if (open) acknowledgedDeletion = false;
+	});
+
+	const hasOmitted = $derived(omittedSummaries.length > 0);
+	const requiresAcknowledgement = $derived(hasOmitted && omittedSeverity === 'delete');
+	const canConfirm = $derived(
+		!confirming && (!requiresAcknowledgement || acknowledgedDeletion)
+	);
+	const nothingToDo = $derived(
+		newSummaries.length === 0 &&
+			updatedSummaries.length === 0 &&
+			omittedSummaries.length === 0 &&
+			ambiguousMessages.length === 0
+	);
+
+	function close() {
+		open = false;
+		oncancel?.();
+	}
+</script>
+
+<Modal bind:open {title}>
+	<div class="flex max-h-[70vh] flex-col gap-4 overflow-y-auto text-sm">
+		{#if nothingToDo}
+			<p class="text-slate-600">Nothing to import - this file matches what's already here.</p>
+		{/if}
+
+		{#if newSummaries.length > 0}
+			<div>
+				<p class="font-medium text-emerald-700">{newSummaries.length} new</p>
+				<ul class="mt-1 list-inside list-disc text-slate-600">
+					{#each newSummaries as summary (summary)}
+						<li>{summary}</li>
+					{/each}
+				</ul>
+			</div>
+		{/if}
+
+		{#if updatedSummaries.length > 0}
+			<div>
+				<p class="font-medium text-primary">{updatedSummaries.length} updated</p>
+				<ul class="mt-1 list-inside list-disc text-slate-600">
+					{#each updatedSummaries as summary (summary)}
+						<li>{summary}</li>
+					{/each}
+				</ul>
+			</div>
+		{/if}
+
+		{#if unchangedCount > 0}
+			<p class="text-slate-500">{unchangedCount} unchanged</p>
+		{/if}
+
+		{#if ambiguousMessages.length > 0}
+			<div>
+				<p class="font-medium text-amber-700">
+					{ambiguousMessages.length} ambiguous - skipped, resolve manually
+				</p>
+				<ul class="mt-1 list-inside list-disc text-slate-600">
+					{#each ambiguousMessages as message (message)}
+						<li>{message}</li>
+					{/each}
+				</ul>
+			</div>
+		{/if}
+
+		{#if hasOmitted}
+			<div
+				class="rounded-card border p-3 {omittedSeverity === 'delete'
+					? 'border-red-200 bg-red-50'
+					: 'border-slate-200 bg-slate-50'}"
+			>
+				<p class="font-medium {omittedSeverity === 'delete' ? 'text-red-700' : 'text-slate-700'}">
+					{omittedSummaries.length}
+					{omittedSeverity === 'delete'
+						? 'will be permanently deleted'
+						: 'not in this file - will be disabled'}
+				</p>
+				<ul class="mt-1 list-inside list-disc text-slate-600">
+					{#each omittedSummaries as summary (summary)}
+						<li>{summary}</li>
+					{/each}
+				</ul>
+				{#if omittedSeverity === 'delete'}
+					<label class="mt-3 flex items-start gap-2 text-red-700">
+						<input type="checkbox" class="mt-0.5" bind:checked={acknowledgedDeletion} />
+						<span>I understand this cannot be undone.</span>
+					</label>
+				{/if}
+			</div>
+		{/if}
+	</div>
+
+	<div class="mt-4 flex justify-end gap-2">
+		<Button variant="secondary" onclick={close} disabled={confirming}>Cancel</Button>
+		<Button onclick={onconfirm} disabled={!canConfirm || nothingToDo}>
+			{confirming ? 'Importing…' : 'Confirm import'}
+		</Button>
+	</div>
+</Modal>

--- a/frontend/src/routes/(app)/accounts/[id]/+page.svelte
+++ b/frontend/src/routes/(app)/accounts/[id]/+page.svelte
@@ -1,16 +1,7 @@
 <script lang="ts">
 	import { page } from '$app/stores';
 	import { getAccount, listAccounts } from '$lib/api/accounts';
-	import {
-		createBill,
-		deleteBill,
-		exportBillsCsv,
-		importBillsCsv,
-		listBills,
-		updateBill,
-		type BillImportRowError
-	} from '$lib/api/bills';
-	import { ApiError } from '$lib/api';
+	import { createBill, deleteBill, listBills, updateBill } from '$lib/api/bills';
 	import type { BankAccount, Bill, RecurrenceType } from '$lib/api/types';
 	import { accountSuffix, todayIso } from '$lib/format';
 	import AccountNav from '$lib/components/AccountNav.svelte';
@@ -72,11 +63,6 @@
 	let moveTargetAccountId = $state('');
 	let moving = $state(false);
 	let showMoveModal = $state(false);
-
-	let exporting = $state(false);
-	let importing = $state(false);
-	let importErrors = $state<BillImportRowError[] | null>(null);
-	let fileInputEl = $state<HTMLInputElement | undefined>();
 
 	let editingBill = $state<Bill | null>(null);
 	let editName = $state('');
@@ -172,54 +158,6 @@
 		}
 	}
 
-	async function handleExport() {
-		exporting = true;
-		error = null;
-		try {
-			const blob = await exportBillsCsv(accountId);
-			const url = URL.createObjectURL(blob);
-			const link = document.createElement('a');
-			link.href = url;
-			link.download = `bills-${accountId}.csv`;
-			link.click();
-			URL.revokeObjectURL(url);
-		} catch (err) {
-			error = err instanceof Error ? err.message : String(err);
-		} finally {
-			exporting = false;
-		}
-	}
-
-	function handleImportClick() {
-		fileInputEl?.click();
-	}
-
-	async function handleImportFile(event: Event) {
-		const file = (event.target as HTMLInputElement).files?.[0];
-		if (!file) return;
-		importing = true;
-		error = null;
-		importErrors = null;
-		try {
-			await importBillsCsv(accountId, file);
-			await loadBills();
-		} catch (err) {
-			if (err instanceof ApiError && err.body && typeof err.body === 'object' && 'detail' in err.body) {
-				const detail = (err.body as { detail?: { errors?: BillImportRowError[] } }).detail;
-				if (detail?.errors) {
-					importErrors = detail.errors;
-				} else {
-					error = 'Import failed.';
-				}
-			} else {
-				error = err instanceof Error ? err.message : String(err);
-			}
-		} finally {
-			importing = false;
-			if (fileInputEl) fileInputEl.value = '';
-		}
-	}
-
 	function openMoveModal(bill: Bill) {
 		movingBill = bill;
 		moveTargetAccountId = '';
@@ -289,46 +227,25 @@
 </script>
 
 <AccountNav {accountId} current="bills" />
-<div class="mt-2 flex items-center justify-between">
-	<h1 class="text-2xl font-semibold text-text">
-		Bills{accountSuffix(account)}
-	</h1>
-	<div class="flex gap-2">
-		<input
-			bind:this={fileInputEl}
-			type="file"
-			accept=".csv,text/csv"
-			class="hidden"
-			onchange={handleImportFile}
-		/>
-		<Button variant="secondary" onclick={handleImportClick} disabled={importing}>
-			{importing ? 'Importing…' : 'Import CSV'}
-		</Button>
-		<Button variant="secondary" onclick={handleExport} disabled={exporting}>
-			{exporting ? 'Exporting…' : 'Export CSV'}
-		</Button>
-	</div>
-</div>
+<h1 class="mt-2 text-2xl font-semibold text-text">
+	Bills{accountSuffix(account)}
+</h1>
 
 {#if error}
 	<p class="mt-4 rounded-card bg-red-50 px-4 py-2 text-sm text-red-700">{error}</p>
 {/if}
 
-{#if importErrors}
-	<div class="mt-4 rounded-card bg-red-50 px-4 py-2 text-sm text-red-700">
-		<p class="font-medium">Import failed - fix these rows and try again:</p>
-		<ul class="mt-1 list-disc pl-5">
-			{#each importErrors as rowError (rowError.row)}
-				<li>Row {rowError.row}: {rowError.message}</li>
-			{/each}
-		</ul>
-	</div>
-{/if}
-
 <Card>
 	<form class="flex flex-wrap items-end gap-4" onsubmit={handleCreate}>
 		<Input label="Name" bind:value={name} placeholder="Rent" required />
-		<Input label="Amount ($)" type="number" bind:value={amount} placeholder="1500.00" required />
+		<Input
+			label="Amount ($)"
+			type="number"
+			step="0.01"
+			bind:value={amount}
+			placeholder="1500.00"
+			required
+		/>
 		<Select
 			label="Frequency"
 			bind:value={recurrenceType}
@@ -443,7 +360,7 @@
 	{#if editingBill}
 		<form class="flex flex-col gap-4" onsubmit={handleEditSubmit}>
 			<Input label="Name" bind:value={editName} required />
-			<Input label="Amount ($)" type="number" bind:value={editAmount} required />
+			<Input label="Amount ($)" type="number" step="0.01" bind:value={editAmount} required />
 			<Select
 				label="Frequency"
 				bind:value={editRecurrenceType}

--- a/frontend/src/routes/(app)/accounts/[id]/settings/+page.svelte
+++ b/frontend/src/routes/(app)/accounts/[id]/settings/+page.svelte
@@ -1,0 +1,517 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+	import { getAccount } from '$lib/api/accounts';
+	import {
+		commitBillImportCsv,
+		exportBillsCsv,
+		listBills,
+		previewBillImportCsv
+	} from '$lib/api/bills';
+	import {
+		commitTransactionImportCsv,
+		exportTransactionsCsv,
+		listTransactions,
+		previewTransactionImportCsv
+	} from '$lib/api/transactions';
+	import {
+		commitWindfallImportCsv,
+		exportWindfallsCsv,
+		previewWindfallImportCsv
+	} from '$lib/api/windfalls';
+	import { ApiError } from '$lib/api';
+	import type {
+		BankAccount,
+		Bill,
+		BillImportPreview,
+		ImportRowIssue,
+		Transaction,
+		TransactionImportPreview,
+		Windfall,
+		WindfallImportPreview
+	} from '$lib/api/types';
+	import { accountSuffix } from '$lib/format';
+	import AccountNav from '$lib/components/AccountNav.svelte';
+	import Button from '$lib/components/Button.svelte';
+	import Card from '$lib/components/Card.svelte';
+	import ImportPreviewModal from '$lib/components/ImportPreviewModal.svelte';
+	import { onMount } from 'svelte';
+
+	const accountId = $derived(Number($page.params.id));
+
+	let account = $state<BankAccount | null>(null);
+
+	onMount(() => {
+		getAccount(accountId).then((a) => (account = a));
+	});
+
+	function formatMoney(cents: number): string {
+		return (cents / 100).toLocaleString(undefined, { style: 'currency', currency: 'USD' });
+	}
+
+	function parseErrorsFrom(err: unknown): ImportRowIssue[] | null {
+		if (
+			err instanceof ApiError &&
+			err.body &&
+			typeof err.body === 'object' &&
+			'detail' in err.body
+		) {
+			const detail = (err.body as { detail?: { errors?: ImportRowIssue[] } }).detail;
+			if (detail?.errors) return detail.errors;
+		}
+		return null;
+	}
+
+	// ---------------------------------------------------------------------
+	// Bills
+	// ---------------------------------------------------------------------
+
+	let billFileInput = $state<HTMLInputElement | undefined>();
+	let billExporting = $state(false);
+	let billPreviewLoading = $state(false);
+	let billCommitting = $state(false);
+	let billPreview = $state<BillImportPreview | null>(null);
+	let billPreviewOpen = $state(false);
+	let billParseErrors = $state<ImportRowIssue[] | null>(null);
+	let billError = $state<string | null>(null);
+	let currentBillsById = $state<Map<number, Bill>>(new Map());
+
+	async function handleBillExport() {
+		billExporting = true;
+		billError = null;
+		try {
+			const blob = await exportBillsCsv(accountId);
+			downloadBlob(blob, `bills-${accountId}.csv`);
+		} catch (err) {
+			billError = err instanceof Error ? err.message : String(err);
+		} finally {
+			billExporting = false;
+		}
+	}
+
+	async function handleBillImportFile(event: Event) {
+		const file = (event.target as HTMLInputElement).files?.[0];
+		if (!file) return;
+		billPreviewLoading = true;
+		billError = null;
+		billParseErrors = null;
+		try {
+			const [preview, current] = await Promise.all([
+				previewBillImportCsv(accountId, file),
+				listBills(accountId)
+			]);
+			billPreview = preview;
+			currentBillsById = new Map(current.map((b) => [b.id, b]));
+			billPreviewOpen = true;
+		} catch (err) {
+			const errors = parseErrorsFrom(err);
+			if (errors) {
+				billParseErrors = errors;
+			} else {
+				billError = err instanceof Error ? err.message : String(err);
+			}
+		} finally {
+			billPreviewLoading = false;
+			if (billFileInput) billFileInput.value = '';
+		}
+	}
+
+	function summarizeNewBill(fields: BillImportPreview['new'][number]): string {
+		return `${fields.name} (${formatMoney(fields.amount_cents)}, ${fields.recurrence_type})`;
+	}
+
+	function summarizeUpdatedBill(update: BillImportPreview['updated'][number]): string {
+		const current = currentBillsById.get(update.id);
+		if (!current) return update.fields.name;
+		const changed: string[] = [];
+		if ((current.notes ?? null) !== (update.fields.notes ?? null)) changed.push('notes');
+		if ((current.end_date ?? null) !== (update.fields.end_date ?? null)) changed.push('end date');
+		if (
+			JSON.stringify(current.recurrence_config) !==
+			JSON.stringify(update.fields.recurrence_config ?? {})
+		) {
+			changed.push('recurrence');
+		}
+		if (current.enabled !== (update.fields.enabled ?? true)) {
+			changed.push(update.fields.enabled ? 're-enabled' : 'disabled');
+		}
+		return `${update.fields.name}${changed.length ? ' — ' + changed.join(', ') : ''}`;
+	}
+
+	function summarizeOmittedBill(bill: Bill): string {
+		return `${bill.name} (${formatMoney(bill.amount_cents)})`;
+	}
+
+	async function handleBillCommit() {
+		if (!billPreview) return;
+		billCommitting = true;
+		billError = null;
+		try {
+			await commitBillImportCsv(accountId, {
+				new: billPreview.new,
+				updated: billPreview.updated,
+				omitted_ids: billPreview.omitted.map((b) => b.id)
+			});
+			billPreviewOpen = false;
+			billPreview = null;
+		} catch (err) {
+			billError = err instanceof Error ? err.message : String(err);
+		} finally {
+			billCommitting = false;
+		}
+	}
+
+	// ---------------------------------------------------------------------
+	// Transactions
+	// ---------------------------------------------------------------------
+
+	let transactionFileInput = $state<HTMLInputElement | undefined>();
+	let transactionExporting = $state(false);
+	let transactionPreviewLoading = $state(false);
+	let transactionCommitting = $state(false);
+	let transactionPreview = $state<TransactionImportPreview | null>(null);
+	let transactionPreviewOpen = $state(false);
+	let transactionParseErrors = $state<ImportRowIssue[] | null>(null);
+	let transactionError = $state<string | null>(null);
+	let currentTransactionsById = $state<Map<number, Transaction>>(new Map());
+
+	async function handleTransactionExport() {
+		transactionExporting = true;
+		transactionError = null;
+		try {
+			const blob = await exportTransactionsCsv(accountId);
+			downloadBlob(blob, `transactions-${accountId}.csv`);
+		} catch (err) {
+			transactionError = err instanceof Error ? err.message : String(err);
+		} finally {
+			transactionExporting = false;
+		}
+	}
+
+	async function handleTransactionImportFile(event: Event) {
+		const file = (event.target as HTMLInputElement).files?.[0];
+		if (!file) return;
+		transactionPreviewLoading = true;
+		transactionError = null;
+		transactionParseErrors = null;
+		try {
+			const [preview, current] = await Promise.all([
+				previewTransactionImportCsv(accountId, file),
+				listTransactions(accountId)
+			]);
+			transactionPreview = preview;
+			currentTransactionsById = new Map(current.map((t) => [t.id, t]));
+			transactionPreviewOpen = true;
+		} catch (err) {
+			const errors = parseErrorsFrom(err);
+			if (errors) {
+				transactionParseErrors = errors;
+			} else {
+				transactionError = err instanceof Error ? err.message : String(err);
+			}
+		} finally {
+			transactionPreviewLoading = false;
+			if (transactionFileInput) transactionFileInput.value = '';
+		}
+	}
+
+	function summarizeNewTransaction(fields: TransactionImportPreview['new'][number]): string {
+		return `${formatMoney(fields.amount_cents)} on ${fields.date}${fields.description ? ` (${fields.description})` : ''}`;
+	}
+
+	function summarizeUpdatedTransaction(
+		update: TransactionImportPreview['updated'][number]
+	): string {
+		const current = currentTransactionsById.get(update.id);
+		const label = `${formatMoney(update.fields.amount_cents)} on ${update.fields.date}`;
+		if (!current) return label;
+		return `${label} — bill link ${update.fields.bill_id ? 'set' : 'cleared'}`;
+	}
+
+	function summarizeOmittedTransaction(transaction: Transaction): string {
+		return `${formatMoney(transaction.amount_cents)} on ${transaction.date}${
+			transaction.description ? ` (${transaction.description})` : ''
+		}`;
+	}
+
+	async function handleTransactionCommit() {
+		if (!transactionPreview) return;
+		transactionCommitting = true;
+		transactionError = null;
+		try {
+			await commitTransactionImportCsv(accountId, {
+				new: transactionPreview.new,
+				updated: transactionPreview.updated,
+				omitted_ids: transactionPreview.omitted.map((t) => t.id)
+			});
+			transactionPreviewOpen = false;
+			transactionPreview = null;
+		} catch (err) {
+			transactionError = err instanceof Error ? err.message : String(err);
+		} finally {
+			transactionCommitting = false;
+		}
+	}
+
+	// ---------------------------------------------------------------------
+	// Windfalls
+	// ---------------------------------------------------------------------
+
+	let windfallFileInput = $state<HTMLInputElement | undefined>();
+	let windfallExporting = $state(false);
+	let windfallPreviewLoading = $state(false);
+	let windfallCommitting = $state(false);
+	let windfallPreview = $state<WindfallImportPreview | null>(null);
+	let windfallPreviewOpen = $state(false);
+	let windfallParseErrors = $state<ImportRowIssue[] | null>(null);
+	let windfallError = $state<string | null>(null);
+
+	async function handleWindfallExport() {
+		windfallExporting = true;
+		windfallError = null;
+		try {
+			const blob = await exportWindfallsCsv(accountId);
+			downloadBlob(blob, `windfalls-${accountId}.csv`);
+		} catch (err) {
+			windfallError = err instanceof Error ? err.message : String(err);
+		} finally {
+			windfallExporting = false;
+		}
+	}
+
+	async function handleWindfallImportFile(event: Event) {
+		const file = (event.target as HTMLInputElement).files?.[0];
+		if (!file) return;
+		windfallPreviewLoading = true;
+		windfallError = null;
+		windfallParseErrors = null;
+		try {
+			windfallPreview = await previewWindfallImportCsv(accountId, file);
+			windfallPreviewOpen = true;
+		} catch (err) {
+			const errors = parseErrorsFrom(err);
+			if (errors) {
+				windfallParseErrors = errors;
+			} else {
+				windfallError = err instanceof Error ? err.message : String(err);
+			}
+		} finally {
+			windfallPreviewLoading = false;
+			if (windfallFileInput) windfallFileInput.value = '';
+		}
+	}
+
+	function summarizeNewWindfall(fields: WindfallImportPreview['new'][number]): string {
+		return `${fields.name} (${formatMoney(fields.amount_cents)}, expected ${fields.expected_date})`;
+	}
+
+	function summarizeUpdatedWindfall(update: WindfallImportPreview['updated'][number]): string {
+		return `${update.fields.name} — ${update.fields.enabled ? 're-enabled' : 'disabled'}`;
+	}
+
+	function summarizeOmittedWindfall(windfall: Windfall): string {
+		return `${windfall.name} (${formatMoney(windfall.amount_cents)}, expected ${windfall.expected_date})`;
+	}
+
+	async function handleWindfallCommit() {
+		if (!windfallPreview) return;
+		windfallCommitting = true;
+		windfallError = null;
+		try {
+			await commitWindfallImportCsv(accountId, {
+				new: windfallPreview.new,
+				updated: windfallPreview.updated,
+				omitted_ids: windfallPreview.omitted.map((w) => w.id)
+			});
+			windfallPreviewOpen = false;
+			windfallPreview = null;
+		} catch (err) {
+			windfallError = err instanceof Error ? err.message : String(err);
+		} finally {
+			windfallCommitting = false;
+		}
+	}
+
+	// ---------------------------------------------------------------------
+
+	function downloadBlob(blob: Blob, filename: string) {
+		const url = URL.createObjectURL(blob);
+		const link = document.createElement('a');
+		link.href = url;
+		link.download = filename;
+		link.click();
+		URL.revokeObjectURL(url);
+	}
+</script>
+
+<AccountNav {accountId} current="settings" />
+<h1 class="mt-2 text-2xl font-semibold text-text">Settings{accountSuffix(account)}</h1>
+<p class="mt-1 text-sm text-slate-500">
+	Import and export CSVs for this account's bills, transactions, and windfalls. Re-importing an
+	edited export reconciles against what's already here instead of duplicating it — see each
+	section below for how matches, updates, and rows left off the file are handled.
+</p>
+
+<div class="mt-6 flex flex-col gap-6">
+	<Card>
+		<div class="flex items-center justify-between">
+			<h2 class="text-lg font-semibold text-text">Bills</h2>
+			<div class="flex gap-2">
+				<input
+					bind:this={billFileInput}
+					type="file"
+					accept=".csv,text/csv"
+					class="hidden"
+					onchange={handleBillImportFile}
+				/>
+				<Button
+					variant="secondary"
+					onclick={() => billFileInput?.click()}
+					disabled={billPreviewLoading}
+				>
+					{billPreviewLoading ? 'Reading…' : 'Import CSV'}
+				</Button>
+				<Button variant="secondary" onclick={handleBillExport} disabled={billExporting}>
+					{billExporting ? 'Exporting…' : 'Export CSV'}
+				</Button>
+			</div>
+		</div>
+		<p class="mt-2 text-sm text-slate-500">
+			A bill matching an existing one (same name, amount, frequency, and start date) updates it in
+			place. A bill left off the file gets disabled, not deleted — its history is kept.
+		</p>
+		{#if billError}
+			<p class="mt-3 rounded-card bg-red-50 px-3 py-2 text-sm text-red-700">{billError}</p>
+		{/if}
+		{#if billParseErrors}
+			<ul class="mt-3 rounded-card bg-red-50 px-3 py-2 text-sm text-red-700">
+				{#each billParseErrors as rowError (rowError.row)}
+					<li>Row {rowError.row}: {rowError.message}</li>
+				{/each}
+			</ul>
+		{/if}
+	</Card>
+
+	<Card>
+		<div class="flex items-center justify-between">
+			<h2 class="text-lg font-semibold text-text">Transactions</h2>
+			<div class="flex gap-2">
+				<input
+					bind:this={transactionFileInput}
+					type="file"
+					accept=".csv,text/csv"
+					class="hidden"
+					onchange={handleTransactionImportFile}
+				/>
+				<Button
+					variant="secondary"
+					onclick={() => transactionFileInput?.click()}
+					disabled={transactionPreviewLoading}
+				>
+					{transactionPreviewLoading ? 'Reading…' : 'Import CSV'}
+				</Button>
+				<Button variant="secondary" onclick={handleTransactionExport} disabled={transactionExporting}>
+					{transactionExporting ? 'Exporting…' : 'Export CSV'}
+				</Button>
+			</div>
+		</div>
+		<p class="mt-2 text-sm text-slate-500">
+			Link a transaction to a bill with a <code>bill_name</code> column matching that bill's exact
+			name. A transaction left off the file is permanently deleted — there's no history to preserve
+			for transactions, so review the omitted list carefully before confirming.
+		</p>
+		{#if transactionError}
+			<p class="mt-3 rounded-card bg-red-50 px-3 py-2 text-sm text-red-700">{transactionError}</p>
+		{/if}
+		{#if transactionParseErrors}
+			<ul class="mt-3 rounded-card bg-red-50 px-3 py-2 text-sm text-red-700">
+				{#each transactionParseErrors as rowError (rowError.row)}
+					<li>Row {rowError.row}: {rowError.message}</li>
+				{/each}
+			</ul>
+		{/if}
+	</Card>
+
+	<Card>
+		<div class="flex items-center justify-between">
+			<h2 class="text-lg font-semibold text-text">Windfalls</h2>
+			<div class="flex gap-2">
+				<input
+					bind:this={windfallFileInput}
+					type="file"
+					accept=".csv,text/csv"
+					class="hidden"
+					onchange={handleWindfallImportFile}
+				/>
+				<Button
+					variant="secondary"
+					onclick={() => windfallFileInput?.click()}
+					disabled={windfallPreviewLoading}
+				>
+					{windfallPreviewLoading ? 'Reading…' : 'Import CSV'}
+				</Button>
+				<Button variant="secondary" onclick={handleWindfallExport} disabled={windfallExporting}>
+					{windfallExporting ? 'Exporting…' : 'Export CSV'}
+				</Button>
+			</div>
+		</div>
+		<p class="mt-2 text-sm text-slate-500">
+			A windfall matching an existing one (same name, amount, and expected date) updates it in
+			place. A windfall left off the file gets disabled, not deleted.
+		</p>
+		{#if windfallError}
+			<p class="mt-3 rounded-card bg-red-50 px-3 py-2 text-sm text-red-700">{windfallError}</p>
+		{/if}
+		{#if windfallParseErrors}
+			<ul class="mt-3 rounded-card bg-red-50 px-3 py-2 text-sm text-red-700">
+				{#each windfallParseErrors as rowError (rowError.row)}
+					<li>Row {rowError.row}: {rowError.message}</li>
+				{/each}
+			</ul>
+		{/if}
+	</Card>
+</div>
+
+{#if billPreview}
+	<ImportPreviewModal
+		bind:open={billPreviewOpen}
+		title="Import bills"
+		newSummaries={billPreview.new.map(summarizeNewBill)}
+		updatedSummaries={billPreview.updated.map(summarizeUpdatedBill)}
+		unchangedCount={billPreview.unchanged_count}
+		ambiguousMessages={billPreview.ambiguous.map((a) => a.message)}
+		omittedSummaries={billPreview.omitted.map(summarizeOmittedBill)}
+		omittedSeverity="disable"
+		confirming={billCommitting}
+		onconfirm={handleBillCommit}
+	/>
+{/if}
+
+{#if transactionPreview}
+	<ImportPreviewModal
+		bind:open={transactionPreviewOpen}
+		title="Import transactions"
+		newSummaries={transactionPreview.new.map(summarizeNewTransaction)}
+		updatedSummaries={transactionPreview.updated.map(summarizeUpdatedTransaction)}
+		unchangedCount={transactionPreview.unchanged_count}
+		ambiguousMessages={transactionPreview.ambiguous.map((a) => a.message)}
+		omittedSummaries={transactionPreview.omitted.map(summarizeOmittedTransaction)}
+		omittedSeverity="delete"
+		confirming={transactionCommitting}
+		onconfirm={handleTransactionCommit}
+	/>
+{/if}
+
+{#if windfallPreview}
+	<ImportPreviewModal
+		bind:open={windfallPreviewOpen}
+		title="Import windfalls"
+		newSummaries={windfallPreview.new.map(summarizeNewWindfall)}
+		updatedSummaries={windfallPreview.updated.map(summarizeUpdatedWindfall)}
+		unchangedCount={windfallPreview.unchanged_count}
+		ambiguousMessages={windfallPreview.ambiguous.map((a) => a.message)}
+		omittedSummaries={windfallPreview.omitted.map(summarizeOmittedWindfall)}
+		omittedSeverity="disable"
+		confirming={windfallCommitting}
+		onconfirm={handleWindfallCommit}
+	/>
+{/if}

--- a/frontend/src/routes/(app)/accounts/[id]/windfalls/+page.svelte
+++ b/frontend/src/routes/(app)/accounts/[id]/windfalls/+page.svelte
@@ -5,6 +5,7 @@
 	import type { BankAccount, Windfall } from '$lib/api/types';
 	import { accountSuffix } from '$lib/format';
 	import AccountNav from '$lib/components/AccountNav.svelte';
+	import Badge from '$lib/components/Badge.svelte';
 	import Button from '$lib/components/Button.svelte';
 	import Card from '$lib/components/Card.svelte';
 	import DatePicker from '$lib/components/DatePicker.svelte';
@@ -99,6 +100,15 @@
 			error = err instanceof Error ? err.message : String(err);
 		} finally {
 			creating = false;
+		}
+	}
+
+	async function toggleEnabled(windfall: Windfall) {
+		try {
+			await updateWindfall(accountId, windfall.id, { enabled: !windfall.enabled });
+			await loadWindfalls();
+		} catch (err) {
+			error = err instanceof Error ? err.message : String(err);
 		}
 	}
 
@@ -214,6 +224,7 @@
 					<th class="px-4 py-2 font-medium">Name</th>
 					<th class="px-4 py-2 text-right font-medium">Amount</th>
 					<th class="px-4 py-2"></th>
+					<th class="px-4 py-2"></th>
 				</tr>
 			</thead>
 			<tbody>
@@ -223,6 +234,11 @@
 						<td class="px-4 py-2">{windfall.name}</td>
 						<td class="px-4 py-2 text-right text-emerald-700">
 							{formatAmount(windfall.amount_cents)}
+						</td>
+						<td class="px-4 py-2">
+							<button onclick={() => toggleEnabled(windfall)}>
+								<Badge enabled={windfall.enabled} />
+							</button>
 						</td>
 						<td class="px-4 py-2 text-right">
 							<RowActionsMenu


### PR DESCRIPTION
## Summary
- Extends Bills-only, insert-only CSV import to all three entity types (Bills, Transactions, Windfalls), unified on one new per-account **Settings** page (`/accounts/{id}/settings`, linked from `AccountNav`)
- Reimporting now **reconciles** instead of duplicating: fuzzy field-match per type (no id column round-tripped through the CSV), preview-then-confirm (nothing writes until you click Confirm), matched rows update in place
- Deliberately designed so reconciliation never destroys history:
  - **Bills**: a row missing from the CSV gets **disabled**, not deleted (reuses the same mechanism as auto-disabling expired bills) — `bill_events`/`bill_history`/`cycle_overrides` all survive
  - **Windfalls**: same soft-delete treatment — required adding `Windfall.enabled` (new migration), which didn't exist before, threaded through forecast/dashboard filtering and a new enabled/disabled badge+toggle on the Windfalls page
  - **Transactions**: no downstream table references a transaction, so an omitted one is genuinely **hard-deleted** — gated behind an explicit "I understand this cannot be undone" acknowledgement in the UI
  - A CSV row whose match key collides with 2+ existing rows is flagged **ambiguous** and excluded from the commit rather than guessed at
- Transaction↔Bill linking in the CSV is by the bill's **name** (not id); unresolved/ambiguous names import unlinked with a warning
- Also fixes a reported bug found along the way: the Bills page's Amount input was missing `step="0.01"` (present on Transactions'/Windfalls' equivalents), so browsers rounded entries to whole dollars — couldn't enter e.g. 79.99

Full design writeup is in the `docs/ROADMAP.md` 2026-07-15 changelog entry.

## Test plan
- [x] Backend: 192 tests pass (44 new — `test_csv_match.py` for the shared reconciliation matcher, plus preview/commit/reconciliation/omission coverage in `test_bills_api.py`/`test_transactions_api.py`/`test_windfalls_api.py`), `ruff check` clean
- [x] Frontend: `svelte-check` (0 errors), `eslint` clean, `vitest` (23 tests) pass, production `vite build` succeeds including the new Settings route
- [ ] **Not yet verified in-browser** — the harness's safety gate blocked flipping `DEV_AUTH_BYPASS`/`PUBLIC_DEV_AUTH_BYPASS` to `true` for local click-through testing without your explicit go-ahead. Worth a manual pass before merging: export/reimport round-trip on each tab, an edited-then-reimported row showing as "updated", an omitted row showing correctly (disabled for Bills/Windfalls, delete-confirmation for Transactions), and the Amount-field decimal fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)